### PR TITLE
ci: add concurrency cancellation and fail-fast gate ordering

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -9,9 +9,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   coverage-go:
     name: RuneGate/Coverage/Go
+    needs: [security-secrets, security-sast]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Closes #6

## Changes
- `concurrency: cancel-in-progress: true` — new push cancels stale runs
- Full test suite `needs` security gates — failing CVE/secret scan skips `go test` entirely