### PR TITLE
ci: eliminate QEMU for arm64 via Go native cross-compilation

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -86,6 +86,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Detect build platform
+        id: buildplatform
+        run: echo "value=linux/$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" >> "$GITHUB_OUTPUT"
       - name: Build amd64 image and smoke test
         uses: docker/build-push-action@v7
         with:
@@ -95,6 +98,7 @@ jobs:
           load: true
           push: false
           tags: rune-operator:rune-ci
+          build-args: BUILDPLATFORM=${{ steps.buildplatform.outputs.value }}
           cache-from: ${{ github.event_name == 'push' && 'type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache' || 'type=gha' }}
           cache-to: ${{ github.event_name == 'push' && 'type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache,mode=max' || 'type=gha,mode=max' }}
       - run: docker run --rm rune-operator:rune-ci --help >/dev/null
@@ -110,6 +114,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
+      - name: Detect build platform
+        id: buildplatform
+        run: echo "value=linux/$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" >> "$GITHUB_OUTPUT"
       - uses: docker/login-action@v3
         if: github.event_name == 'push'
         with:
@@ -124,6 +131,7 @@ jobs:
           platforms: linux/amd64
           load: true
           tags: rune-operator:rune-ci
+          build-args: BUILDPLATFORM=${{ steps.buildplatform.outputs.value }}
           cache-from: ${{ github.event_name == 'push' && 'type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache' || 'type=gha' }}
       - name: Generate SBOM — CycloneDX via Syft
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 ARG GO_VERSION=1.25
 ARG BUILDPLATFORM
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:${GO_VERSION}-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 WORKDIR /workspace
 
 RUN apk add --no-cache git ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 ARG GO_VERSION=1.25
+ARG BUILDPLATFORM
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 WORKDIR /workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 ARG GO_VERSION=1.25
 ARG BUILDPLATFORM
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:${GO_VERSION}-alpine AS builder
 WORKDIR /workspace
 
 RUN apk add --no-cache git ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 ARG GO_VERSION=1.25
-FROM golang:${GO_VERSION}-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 WORKDIR /workspace
 
 RUN apk add --no-cache git ca-certificates


### PR DESCRIPTION
## Summary
- Add `ARG BUILDPLATFORM` before the `FROM --platform=$BUILDPLATFORM` line so the builder stage runs on the native build host instead of under QEMU emulation
- Fix CI jobs (smoke, SBOM) that use `docker buildx build --platform linux/amd64`: BuildKit's `docker-container` driver does **not** auto-populate `BUILDPLATFORM` for single-platform builds, so we detect the runner's native platform at runtime via `uname -m` and pass it as an explicit `build-args` parameter; multi-platform builds (publish job) still receive it automatically from BuildKit

## Expected impact
- Build time drops from ~19 min to ~3-5 min per build step
- Pipeline total from ~42 min to ~15 min
- All CI jobs (smoke, SBOM, publish) build correctly on both amd64 and arm64 runners

## Test plan
- [x] CI passes — verify the image builds successfully for both amd64 and arm64
- [x] Smoke test passes — `docker run --rm rune-operator:rune-ci --help`

Closes #11