### PR TITLE
ci: switch Docker cache to GHCR registry and remove QEMU from smoke

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -74,19 +74,18 @@ jobs:
     name: RuneGate/CLI-and-API-Smoke/Go-Operator-Container
     needs: [feature-go]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
-      - name: Build multi-arch (amd64 + arm64)
-        uses: docker/build-push-action@v7
+      - uses: docker/login-action@v3
         with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: false
-          tags: rune-operator:rune-ci
-      - name: Load amd64 image and smoke test
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build amd64 image and smoke test
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -95,6 +94,8 @@ jobs:
           load: true
           push: false
           tags: rune-operator:rune-ci
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache,mode=max
       - run: docker run --rm rune-operator:rune-ci --help >/dev/null
 
   security-sbom:
@@ -105,11 +106,24 @@ jobs:
       id-token: write
       attestations: write
       contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
-      - run: docker build -t rune-operator:rune-ci -f Dockerfile .
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: rune-operator:rune-ci
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache
       - name: Generate SBOM — CycloneDX via Syft
         run: |
           set -euo pipefail
@@ -262,6 +276,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.image_name }}:${{ steps.meta.outputs.image_tag }}
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache,mode=max
       - name: Notify rune-charts to sync image tag
         env:
           CROSS_REPO_TOKEN: ${{ secrets.RUNE_CHARTS_BOT_TOKEN }}

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -81,6 +81,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
+        if: github.event_name == 'push'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -94,8 +95,8 @@ jobs:
           load: true
           push: false
           tags: rune-operator:rune-ci
-          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache
-          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache,mode=max
+          cache-from: ${{ github.event_name == 'push' && 'type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache' || 'type=gha' }}
+          cache-to: ${{ github.event_name == 'push' && 'type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache,mode=max' || 'type=gha,mode=max' }}
       - run: docker run --rm rune-operator:rune-ci --help >/dev/null
 
   security-sbom:
@@ -106,11 +107,11 @@ jobs:
       id-token: write
       attestations: write
       contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
+        if: github.event_name == 'push'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -123,7 +124,7 @@ jobs:
           platforms: linux/amd64
           load: true
           tags: rune-operator:rune-ci
-          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache
+          cache-from: ${{ github.event_name == 'push' && 'type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache' || 'type=gha' }}
       - name: Generate SBOM — CycloneDX via Syft
         run: |
           set -euo pipefail
@@ -276,8 +277,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.image_name }}:${{ steps.meta.outputs.image_tag }}
-          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache
-          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache,mode=max
+          cache-from: type=registry,ref=${{ steps.meta.outputs.image_name }}:buildcache
+          cache-to: type=registry,ref=${{ steps.meta.outputs.image_name }}:buildcache,mode=max
       - name: Notify rune-charts to sync image tag
         env:
           CROSS_REPO_TOKEN: ${{ secrets.RUNE_CHARTS_BOT_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace job-scoped GHA cache with cross-job GHCR registry cache for all Docker builds
- Remove redundant multi-arch verification build from smoke job (amd64 load suffices)
- Replace bare `docker build` with `docker/build-push-action` in SBOM job for cache reuse
- Add GHCR login where needed for registry cache writes

## Expected impact
- SBOM job drops from ~4 min to ~30s (cache hit instead of rebuild)
- Publish job benefits from shared cache across jobs and workflows
- Release builds gain cache from quality-gates pipeline

## Test plan
- [ ] CI passes — all quality gates green
- [ ] Smoke test builds and runs successfully
- [ ] SBOM generation works with new build-push-action setup

Closes #12, #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)