### PR TITLE
feat(security): CODEOWNERS gate + OpenVEX permanent wont-fix register

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require 1 review for any change to VEX risk-acceptance documents.
+# VEX entries are security decisions — they must not be auto-merged.
+.vex/   @lpasquali

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
 # Assign @lpasquali as code owner for .vex/ risk-acceptance documents.
-# Enforcement as a required approval depends on branch protection being
-# configured to require review from Code Owners.
-.vex/   @lpasquali
+# Enforcement requires branch protection with "Require review from Code Owners"
+# enabled. To gate only .vex/ changes while keeping other PRs review-free,
+# set required_approving_review_count=0 and enable "Require review from Code
+# Owners" — GitHub then requires 1 approval for PRs touching this path only.
+/.vex/   @lpasquali

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
-# Require 1 review for any change to VEX risk-acceptance documents.
-# VEX entries are security decisions — they must not be auto-merged.
+# Assign @lpasquali as code owner for .vex/ risk-acceptance documents.
+# Enforcement as a required approval depends on branch protection being
+# configured to require review from Code Owners.
 .vex/   @lpasquali


### PR DESCRIPTION
## Changes

### .github/CODEOWNERS
Require 1 approving review for any PR touching `.vex/` files.

Closes #15