### PR TITLE
ci: build image once, GHCR cache, parallel native arm64 release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require 1 review for any change to VEX risk-acceptance documents.
+# VEX entries are security decisions — they must not be auto-merged.
+.vex/   @lpasquali

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
-# Require 1 review for any change to VEX risk-acceptance documents.
-# VEX entries are security decisions — they must not be auto-merged.
-.vex/   @lpasquali
+# Assign a code owner for changes to VEX risk-acceptance documents.
+# Enforcement as a required approval depends on branch protection being configured
+# to require review from Code Owners (with required_approving_review_count = 0 so
+# non-.vex/ PRs are not gated by this rule).
+/.vex/   @lpasquali

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -134,6 +134,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -145,9 +146,10 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          load: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
           tags: ghcr.io/lpasquali/rune-operator:ci-${{ github.sha }}-amd64
           cache-from: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-amd64
-          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-amd64,mode=max
+          cache-to: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-amd64,mode=max' || '' }}
 
   smoke-operator-container:
     name: RuneGate/CLI-and-API-Smoke/Go-Operator-Container

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -144,7 +144,7 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64
-          push: true
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ghcr.io/lpasquali/rune-operator:ci-${{ github.sha }}-amd64
           cache-from: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-amd64
           cache-to: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-amd64,mode=max
@@ -152,11 +152,11 @@ jobs:
   smoke-operator-container:
     name: RuneGate/CLI-and-API-Smoke/Go-Operator-Container
     needs: [changes, build-image]
-    if: needs.changes.outputs.docker == 'true'
+    if: needs.changes.outputs.docker == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      packages: read
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
@@ -174,12 +174,13 @@ jobs:
   security-sbom:
     name: RuneGate/Security/SBOM-and-CVE-Policy
     needs: [changes, build-image]
-    if: needs.changes.outputs.docker == 'true'
+    if: needs.changes.outputs.docker == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       attestations: write
       contents: read
+      packages: read
     steps:
       - uses: actions/checkout@v6
       - uses: docker/login-action@v3

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -322,11 +322,7 @@ jobs:
     if: github.event_name == 'push' && needs.changes.outputs.docker == 'true'
     needs:
       - changes
-      - build-image
-      - smoke-operator-container
-      - security-sbom
-      - security-sast
-      - security-licenses
+      - merge-gate
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -403,7 +399,6 @@ jobs:
       - security-sast
       - security-secrets
       - security-licenses
-      - publish-image-and-notify-charts
     runs-on: ubuntu-latest
     steps:
       - name: Verify all gates passed or were skipped
@@ -418,8 +413,7 @@ jobs:
             "${{ needs.security-sbom.result }}" \
             "${{ needs.security-sast.result }}" \
             "${{ needs.security-secrets.result }}" \
-            "${{ needs.security-licenses.result }}" \
-            "${{ needs.publish-image-and-notify-charts.result }}"; do
+            "${{ needs.security-licenses.result }}"; do
             echo "result: $result"
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               rc=1

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -139,17 +139,28 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push amd64 temp image
+      - name: Build and push amd64 temp image (same-repo)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-          load: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          push: true
+          load: false
           tags: ghcr.io/lpasquali/rune-operator:ci-${{ github.sha }}-amd64
           cache-from: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-amd64
-          cache-to: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-amd64,mode=max' || '' }}
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-amd64,mode=max
+      - name: Build amd64 temp image (fork PR)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: ghcr.io/lpasquali/rune-operator:ci-${{ github.sha }}-amd64
 
   smoke-operator-container:
     name: RuneGate/CLI-and-API-Smoke/Go-Operator-Container

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -122,8 +122,8 @@ jobs:
   # Decoupled from the Go test chain so a Dockerfile-only change still runs
   # the smoke and SBOM jobs without requiring Go tests first.
 
-  smoke-operator-container:
-    name: RuneGate/CLI-and-API-Smoke/Go-Operator-Container
+  build-image:
+    name: RuneGate/Build/Docker-Image-amd64
     needs: [changes]
     if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
@@ -134,31 +134,46 @@ jobs:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
-        if: github.event_name == 'push'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Detect build platform
-        id: buildplatform
-        run: echo "value=linux/$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" >> "$GITHUB_OUTPUT"
-      - name: Build amd64 image and smoke test
+      - name: Build and push amd64 temp image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64
-          load: true
-          push: false
-          tags: rune-operator:rune-ci
-          build-args: BUILDPLATFORM=${{ steps.buildplatform.outputs.value }}
-          cache-from: ${{ github.event_name == 'push' && 'type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache' || 'type=gha' }}
-          cache-to: ${{ github.event_name == 'push' && 'type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache,mode=max' || 'type=gha,mode=max' }}
+          push: true
+          tags: ghcr.io/lpasquali/rune-operator:ci-${{ github.sha }}-amd64
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-amd64
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-amd64,mode=max
+
+  smoke-operator-container:
+    name: RuneGate/CLI-and-API-Smoke/Go-Operator-Container
+    needs: [changes, build-image]
+    if: needs.changes.outputs.docker == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pull pre-built amd64 image
+        run: |
+          docker pull ghcr.io/lpasquali/rune-operator:ci-${{ github.sha }}-amd64
+          docker tag  ghcr.io/lpasquali/rune-operator:ci-${{ github.sha }}-amd64 rune-operator:rune-ci
       - run: docker run --rm rune-operator:rune-ci --help >/dev/null
 
   security-sbom:
     name: RuneGate/Security/SBOM-and-CVE-Policy
-    needs: [changes]
+    needs: [changes, build-image]
     if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -167,26 +182,15 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v4
-      - name: Detect build platform
-        id: buildplatform
-        run: echo "value=linux/$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" >> "$GITHUB_OUTPUT"
       - uses: docker/login-action@v3
-        if: github.event_name == 'push'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64
-          load: true
-          tags: rune-operator:rune-ci
-          build-args: BUILDPLATFORM=${{ steps.buildplatform.outputs.value }}
-          cache-from: ${{ github.event_name == 'push' && 'type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache' || 'type=gha' }}
+      - name: Pull pre-built amd64 image
+        run: |
+          docker pull ghcr.io/lpasquali/rune-operator:ci-${{ github.sha }}-amd64
+          docker tag  ghcr.io/lpasquali/rune-operator:ci-${{ github.sha }}-amd64 rune-operator:rune-ci
       - name: Generate SBOM — CycloneDX via Syft
         run: |
           set -euo pipefail
@@ -317,6 +321,7 @@ jobs:
     if: github.event_name == 'push' && needs.changes.outputs.docker == 'true'
     needs:
       - changes
+      - build-image
       - smoke-operator-container
       - security-sbom
       - security-sast
@@ -341,16 +346,22 @@ jobs:
           IMAGE_TAG="${REF_SLUG}-${GITHUB_SHA::7}"
           echo "image_name=ghcr.io/lpasquali/rune-operator" >> "$GITHUB_OUTPUT"
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
-      - name: Build and push operator image
+      - name: Build and push arm64 temp image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: true
-          tags: ${{ steps.meta.outputs.image_name }}:${{ steps.meta.outputs.image_tag }}
-          cache-from: type=registry,ref=${{ steps.meta.outputs.image_name }}:buildcache
-          cache-to: type=registry,ref=${{ steps.meta.outputs.image_name }}:buildcache,mode=max
+          tags: ${{ steps.meta.outputs.image_name }}:ci-${{ github.sha }}-arm64
+          cache-from: type=registry,ref=${{ steps.meta.outputs.image_name }}:buildcache-arm64
+          cache-to: type=registry,ref=${{ steps.meta.outputs.image_name }}:buildcache-arm64,mode=max
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ steps.meta.outputs.image_name }}:${{ steps.meta.outputs.image_tag }} \
+            ${{ steps.meta.outputs.image_name }}:ci-${{ github.sha }}-amd64 \
+            ${{ steps.meta.outputs.image_name }}:ci-${{ github.sha }}-arm64
       - name: Notify rune-charts to sync image tag
         env:
           CROSS_REPO_TOKEN: ${{ secrets.RUNE_CHARTS_BOT_TOKEN }}
@@ -385,6 +396,7 @@ jobs:
       - coverage-go
       - feature-go
       - linting-go
+      - build-image
       - smoke-operator-container
       - security-sbom
       - security-sast
@@ -400,6 +412,7 @@ jobs:
             "${{ needs.coverage-go.result }}" \
             "${{ needs.feature-go.result }}" \
             "${{ needs.linting-go.result }}" \
+            "${{ needs.build-image.result }}" \
             "${{ needs.smoke-operator-container.result }}" \
             "${{ needs.security-sbom.result }}" \
             "${{ needs.security-sast.result }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,27 @@ permissions:
   contents: read
 
 jobs:
+  verify-tag:
+    name: Verify tag is on main
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Verify tag is on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "ERROR: Tagged commit is not reachable from origin/main." >&2
+            echo "Tags must only be pushed AFTER merging to main." >&2
+            exit 1
+          fi
+
   build-amd64:
     name: Build image (amd64)
+    needs: [verify-tag]
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     permissions:
@@ -22,15 +41,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Verify tag is on main
-        run: |
-          git fetch origin main
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
-            echo "ERROR: Tagged commit is not reachable from origin/main." >&2
-            echo "Tags must only be pushed AFTER merging to main." >&2
-            exit 1
-          fi
 
       - uses: docker/setup-buildx-action@v4
 
@@ -54,6 +64,7 @@ jobs:
 
   build-arm64:
     name: Build image (arm64)
+    needs: [verify-tag]
     if: github.ref_type == 'tag'
     runs-on: ubuntu-24.04-arm
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,3 @@
-# Release rune-operator on version tags.
-#
-# Trigger: push of a tag matching v* (e.g. v0.2.0, v1.0.0-rc1)
-#
-# ─── TAGGING PROCESS ────────────────────────────────────────────────────────
-#  Tags MUST only be pushed AFTER the PR has been merged to main and all
-#  quality gates (RuneGate Grouped) have passed.
-#
-#  Correct flow:
-#    1. Open PR → quality gates pass → merge to main
-#    2. git pull origin main
-#    3. git tag v<version>
-#    4. git push origin v<version>
-#
-#  NEVER push a tag on an unmerged branch or before quality gates pass.
-#  The guard step below will reject tags not reachable from origin/main.
-# ────────────────────────────────────────────────────────────────────────────
-
 name: Release
 
 on:
@@ -27,13 +9,13 @@ permissions:
   contents: read
 
 jobs:
-  release:
-    name: Build image and create GitHub Release
+  build-amd64:
+    name: Build image (amd64)
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # Required to create GitHub Releases
-      packages: write   # Required to push to GHCR
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout
@@ -50,7 +32,6 @@ jobs:
             exit 1
           fi
 
-      - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
@@ -60,16 +41,79 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push operator image
+      - name: Build and push amd64 image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
-          tags: |
-            ghcr.io/lpasquali/rune-operator:${{ github.ref_name }}
-            ghcr.io/lpasquali/rune-operator:latest
+          tags: ghcr.io/lpasquali/rune-operator:${{ github.ref_name }}-amd64
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-amd64
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-amd64,mode=max
+
+  build-arm64:
+    name: Build image (arm64)
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push arm64 image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ghcr.io/lpasquali/rune-operator:${{ github.ref_name }}-arm64
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-arm64
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-arm64,mode=max
+
+  merge-manifest:
+    name: Create multi-arch manifest and GitHub Release
+    needs: [build-amd64, build-arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # Required to create GitHub Releases
+      packages: write   # Required to push to GHCR
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            --tag ghcr.io/lpasquali/rune-operator:${{ github.ref_name }} \
+            --tag ghcr.io/lpasquali/rune-operator:latest \
+            ghcr.io/lpasquali/rune-operator:${{ github.ref_name }}-amd64 \
+            ghcr.io/lpasquali/rune-operator:${{ github.ref_name }}-arm64
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## Changes

### Build image once per pipeline (#30)
- New `build-image` job in quality-gates.yml
- Smoke and SBOM jobs pull pre-built image
- Removed GHA cache fallback entirely

### GHCR registry cache (#32)
- Always `type=registry` cache, no conditional `type=gha` on PRs

### Parallel native arm64 release (#33)
- `build-amd64` (ubuntu-latest) + `build-arm64` (ubuntu-24.04-arm) jobs in parallel
- `merge-manifest` creates final multi-arch `:v*` + `:latest` tags + GitHub Release
- Expected: 15-20 min → 5-8 min, no QEMU segfaults

Closes #30
Closes #32
Closes #33