### PR TITLE
fix(ci): gate Docker push on full Merge Gate

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -314,13 +314,10 @@ jobs:
 
   publish-image-and-notify-charts:
     name: RuneGate/CD/Publish-Image-and-Notify-Charts
-    if: github.event_name == 'push' && needs.changes.outputs.docker == 'true'
+    if: github.event_name == 'push' && needs.changes.outputs.docker == 'true' && needs.merge-gate.result == 'success'
     needs:
       - changes
-      - smoke-operator-container
-      - security-sbom
-      - security-sast
-      - security-licenses
+      - merge-gate
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -390,7 +387,6 @@ jobs:
       - security-sast
       - security-secrets
       - security-licenses
-      - publish-image-and-notify-charts
     runs-on: ubuntu-latest
     steps:
       - name: Verify all gates passed or were skipped
@@ -404,8 +400,7 @@ jobs:
             "${{ needs.security-sbom.result }}" \
             "${{ needs.security-sast.result }}" \
             "${{ needs.security-secrets.result }}" \
-            "${{ needs.security-licenses.result }}" \
-            "${{ needs.publish-image-and-notify-charts.result }}"; do
+            "${{ needs.security-licenses.result }}"; do
             echo "result: $result"
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               rc=1


### PR DESCRIPTION
## Summary

- `publish-image-and-notify-charts` previously only waited on `smoke-operator-container`, `security-sbom`, `security-sast`, and `security-licenses` — `coverage-go`, `feature-go`, `linting-go`, and critically `security-secrets` were all missing
- Restructured so publish depends on `merge-gate`, which already aggregates every quality job (including `security-secrets`)
- Removed `publish-image-and-notify-charts` from `merge-gate`'s `needs:` to break the circular dependency

New chain: `[all quality jobs] → merge-gate → publish-image-and-notify-charts`

Also fixes: missing `security-secrets` gate (closes the gap vs `rune` and `rune-ui`).

Closes #22

## Test plan

- [ ] Push a commit touching `.go` files with a failing test → verify `merge-gate` fails and `RuneGate/CD/Publish-Image-and-Notify-Charts` is skipped (no image pushed)
- [ ] Push a clean commit → verify `merge-gate` passes and image is pushed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)