### PR TITLE
ci: align quality gates and Docker builds with rune

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require 1 review for any change to VEX risk-acceptance documents.
+# VEX entries are security decisions — they must not be auto-merged.
+.vex/   @lpasquali

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
 # Assign @lpasquali as code owner for .vex/ risk-acceptance documents.
-# Enforcement as a required approval depends on branch protection being
-# configured to require review from Code Owners.
-.vex/   @lpasquali
+# Enforcement requires branch protection with "Require review from Code Owners"
+# enabled. To gate only .vex/ changes while keeping other PRs review-free,
+# set required_approving_review_count=0 and enable "Require review from Code
+# Owners" — GitHub then requires 1 approval for PRs touching this path only.
+/.vex/   @lpasquali

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
-# Require 1 review for any change to VEX risk-acceptance documents.
-# VEX entries are security decisions — they must not be auto-merged.
+# Assign @lpasquali as code owner for .vex/ risk-acceptance documents.
+# Enforcement as a required approval depends on branch protection being
+# configured to require review from Code Owners.
 .vex/   @lpasquali

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -341,7 +341,9 @@ jobs:
               'gnu affero general public license',
           )
           # Temporary exceptions — keep minimal and document the constraint.
-          allowed_package_exceptions: set[str] = set()
+          # All entries MUST be lowercase; comparison uses pkg.lower().
+          _raw_exceptions: set[str] = set()
+          allowed_package_exceptions = {e.lower() for e in _raw_exceptions}
 
           # go-licenses report emits CSV: package,license_url,license_type
           text = Path('licenses-go.txt').read_text(encoding='utf-8')

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -60,7 +60,7 @@ jobs:
 
   coverage-go:
     name: RuneGate/Coverage/Go
-    needs: [changes]
+    needs: [changes, security-secrets]
     if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -104,7 +104,7 @@ jobs:
 
   linting-go:
     name: RuneGate/Linting/Go
-    needs: [changes]
+    needs: [changes, security-secrets]
     if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -306,34 +306,75 @@ jobs:
           go-version: '1.25'
           cache: true
           cache-dependency-path: go.sum
-      - run: |
+      - name: go-licenses — dependency license audit (IEC 62443 4-1 ML4 SM-2)
+        run: |
           go install github.com/google/go-licenses@v1.6.0
           go-licenses report ./... > licenses-go.txt
+          python3 - <<'PY'
+          from pathlib import Path
+
+          # Tokens that identify disallowed licenses (case-insensitive).
+          disallowed_tokens = (
+              'agpl',
+              'gplv3',
+              'gpl v3',
+              'gnu general public license v3',
+              'gnu affero general public license',
+          )
+          # Temporary exceptions — keep minimal and document the constraint.
+          allowed_package_exceptions: set[str] = set()
+
+          rows = Path('licenses-go.txt').read_text(encoding='utf-8').splitlines()
+          blocked = []
+          allowed_hits = []
+          for row in rows:
+              parts = row.split(',')
+              if len(parts) < 3:
+                  continue
+              pkg, _, license_name = parts[0].strip(), parts[1].strip(), parts[2].strip()
+              lic_lower = license_name.lower()
+              if any(token in lic_lower for token in disallowed_tokens):
+                  entry = (pkg, license_name)
+                  if pkg.lower() in allowed_package_exceptions:
+                      allowed_hits.append(entry)
+                  else:
+                      blocked.append(entry)
+
+          print(f'license rows: {len(rows)}')
+          print(f'blocked licenses: {len(blocked)}')
+          print(f'allowed exception hits: {len(allowed_hits)}')
+          for name, license_name in allowed_hits[:30]:
+              print(f'ALLOW-EXCEPTION: {name} -> {license_name}')
+          for name, license_name in blocked[:30]:
+              print(f'BLOCK: {name} -> {license_name}')
+
+          if blocked:
+              raise SystemExit(1)
+          PY
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: license-reports
+          path: licenses-go.txt
+          retention-days: 14
 
   # ─── CD gate (push to main/develop only) ─────────────────────────────────────
+  # Parallel native-arch builds (no QEMU) + manifest merge, mirroring rune.
+  # image-meta derives the shared tag once; build-amd64 and build-arm64 run
+  # concurrently on native runners; publish-image-and-notify-charts merges
+  # them into a single multi-arch manifest via imagetools.
 
-  publish-image-and-notify-charts:
-    name: RuneGate/CD/Publish-Image-and-Notify-Charts
-    if: github.event_name == 'push' && needs.changes.outputs.docker == 'true'
+  image-meta:
+    name: RuneGate/CD/Image-Meta
+    if: github.event_name == 'push' && needs.changes.outputs.docker == 'true' && needs.merge-gate.result == 'success'
     needs:
       - changes
-      - smoke-operator-container
-      - security-sbom
-      - security-sast
-      - security-licenses
+      - merge-gate
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+    outputs:
+      image_name: ${{ steps.meta.outputs.image_name }}
+      image_tag: ${{ steps.meta.outputs.image_tag }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Derive image tag
         id: meta
         run: |
@@ -341,16 +382,84 @@ jobs:
           IMAGE_TAG="${REF_SLUG}-${GITHUB_SHA::7}"
           echo "image_name=ghcr.io/lpasquali/rune-operator" >> "$GITHUB_OUTPUT"
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
-      - name: Build and push operator image
+
+  build-amd64:
+    name: RuneGate/CD/Build-amd64
+    needs:
+      - image-meta
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push operator image (amd64)
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
-          tags: ${{ steps.meta.outputs.image_name }}:${{ steps.meta.outputs.image_tag }}
-          cache-from: type=registry,ref=${{ steps.meta.outputs.image_name }}:buildcache
-          cache-to: type=registry,ref=${{ steps.meta.outputs.image_name }}:buildcache,mode=max
+          tags: ${{ needs.image-meta.outputs.image_name }}:${{ needs.image-meta.outputs.image_tag }}-amd64
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-amd64
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-amd64,mode=max
+
+  build-arm64:
+    name: RuneGate/CD/Build-arm64
+    needs:
+      - image-meta
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push operator image (arm64)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ needs.image-meta.outputs.image_name }}:${{ needs.image-meta.outputs.image_tag }}-arm64
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-arm64
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-arm64,mode=max
+
+  publish-image-and-notify-charts:
+    name: RuneGate/CD/Publish-Image-and-Notify-Charts
+    needs:
+      - image-meta
+      - build-amd64
+      - build-arm64
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ needs.image-meta.outputs.image_name }}:${{ needs.image-meta.outputs.image_tag }} \
+            ${{ needs.image-meta.outputs.image_name }}:${{ needs.image-meta.outputs.image_tag }}-amd64 \
+            ${{ needs.image-meta.outputs.image_name }}:${{ needs.image-meta.outputs.image_tag }}-arm64
       - name: Notify rune-charts to sync image tag
         env:
           CROSS_REPO_TOKEN: ${{ secrets.RUNE_CHARTS_BOT_TOKEN }}
@@ -369,8 +478,8 @@ jobs:
             "event_type": "image-published",
             "client_payload": {
               "source_repo": "${GITHUB_REPOSITORY}",
-              "image_name": "${{ steps.meta.outputs.image_name }}",
-              "image_tag": "${{ steps.meta.outputs.image_tag }}"
+              "image_name": "${{ needs.image-meta.outputs.image_name }}",
+              "image_tag": "${{ needs.image-meta.outputs.image_tag }}"
             }
           }
           JSON
@@ -390,7 +499,6 @@ jobs:
       - security-sast
       - security-secrets
       - security-licenses
-      - publish-image-and-notify-charts
     runs-on: ubuntu-latest
     steps:
       - name: Verify all gates passed or were skipped
@@ -404,8 +512,7 @@ jobs:
             "${{ needs.security-sbom.result }}" \
             "${{ needs.security-sast.result }}" \
             "${{ needs.security-secrets.result }}" \
-            "${{ needs.security-licenses.result }}" \
-            "${{ needs.publish-image-and-notify-charts.result }}"; do
+            "${{ needs.security-licenses.result }}"; do
             echo "result: $result"
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               rc=1

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -311,6 +311,7 @@ jobs:
           go install github.com/google/go-licenses@v1.6.0
           go-licenses report ./... > licenses-go.txt
           python3 - <<'PY'
+          import csv
           from pathlib import Path
 
           # Tokens that identify disallowed licenses (case-insensitive).
@@ -324,14 +325,16 @@ jobs:
           # Temporary exceptions — keep minimal and document the constraint.
           allowed_package_exceptions: set[str] = set()
 
-          rows = Path('licenses-go.txt').read_text(encoding='utf-8').splitlines()
+          # go-licenses report emits CSV: package,license_url,license_type
+          text = Path('licenses-go.txt').read_text(encoding='utf-8')
+          reader = csv.reader(text.splitlines())
+          rows = list(reader)
           blocked = []
           allowed_hits = []
-          for row in rows:
-              parts = row.split(',')
+          for parts in rows:
               if len(parts) < 3:
                   continue
-              pkg, _, license_name = parts[0].strip(), parts[1].strip(), parts[2].strip()
+              pkg, license_name = parts[0].strip(), parts[2].strip()
               lic_lower = license_name.lower()
               if any(token in lic_lower for token in disallowed_tokens):
                   entry = (pkg, license_name)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,22 +27,17 @@ permissions:
   contents: read
 
 jobs:
-  release:
-    name: Build image and create GitHub Release
-    if: github.ref_type == 'tag'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write   # Required to create GitHub Releases
-      packages: write   # Required to push to GHCR
+  # ─── Guard ──────────────────────────────────────────────────────────────────
 
+  guard:
+    name: Verify tag is on main
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag'
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Verify tag is on main
-        run: |
+      - run: |
           git fetch origin main
           if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
             echo "ERROR: Tagged commit is not reachable from origin/main." >&2
@@ -50,27 +45,85 @@ jobs:
             exit 1
           fi
 
-      - uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v4
+  # ─── Parallel native-arch builds (no QEMU) ──────────────────────────────────
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
+  build-amd64:
+    name: Release/Build-amd64
+    needs: [guard]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push operator image
+      - name: Build and push operator image (amd64)
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
-          tags: |
-            ghcr.io/lpasquali/rune-operator:${{ github.ref_name }}
-            ghcr.io/lpasquali/rune-operator:latest
+          tags: ghcr.io/lpasquali/rune-operator:${{ github.ref_name }}-amd64
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-amd64
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-amd64,mode=max
 
+  build-arm64:
+    name: Release/Build-arm64
+    needs: [guard]
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push operator image (arm64)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ghcr.io/lpasquali/rune-operator:${{ github.ref_name }}-arm64
+          cache-from: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-arm64
+          cache-to: type=registry,ref=ghcr.io/lpasquali/rune-operator:buildcache-arm64,mode=max
+
+  # ─── Merge manifests + GitHub Release ───────────────────────────────────────
+
+  publish:
+    name: Release/Publish-Manifest-and-Release
+    needs:
+      - build-amd64
+      - build-arm64
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            --tag ghcr.io/lpasquali/rune-operator:${{ github.ref_name }} \
+            --tag ghcr.io/lpasquali/rune-operator:latest \
+            ghcr.io/lpasquali/rune-operator:${{ github.ref_name }}-amd64 \
+            ghcr.io/lpasquali/rune-operator:${{ github.ref_name }}-arm64
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Brings `rune-operator` CI/CD philosophy in line with `rune`.

Closes #25
Closes #26

---

## Changes

### quality-gates.yml

**Gate ordering (#25)**
- `coverage-go` and `linting-go` now declare `needs: [changes, security-secrets]` — secret scanning must pass before any code quality gate runs, matching `rune`'s Python gate ordering
- `publish-image-and-notify-charts` removed from `merge-gate`'s `needs`; instead the CD jobs are gated on `merge-gate.result == 'success'`, exactly mirroring rune's topology

**License enforcement (#25)**
- `security-licenses` now parses `go-licenses` output and blocks on AGPL/GPLv3 packages, with a documented `allowed_package_exceptions` set — matching rune's `pip-licenses` gate philosophy

**Multi-arch native runners (#26)**
- Replaced single QEMU-based `docker/build-push-action` with three new CD jobs:
  - `image-meta` — derives shared tag, gated on merge-gate passing
  - `build-amd64` — native build on `ubuntu-latest`, cache `buildcache-amd64`
  - `build-arm64` — native build on `ubuntu-24.04-arm`, cache `buildcache-arm64`
  - `publish-image-and-notify-charts` — merges with `docker buildx imagetools create`, dispatches to rune-charts

### release.yml (#26)

- Replaced single QEMU-based job with:
  - `guard` — verifies tag is on main
  - `build-amd64` / `build-arm64` — parallel native runners with per-arch caches
  - `publish` — merges manifest (tags `:<version>` + `:latest`), creates GitHub Release

---

## Before / After topology

**Before (quality-gates CD)**
```
changes → smoke + security → publish-image (QEMU, amd64+arm64) → merge-gate (includes CD)
```

**After (quality-gates CD)**
```
changes → smoke + security + tests → merge-gate
                                         ↓
                                    image-meta
                                   ↙           ↘
                             build-amd64    build-arm64   (native runners)
                                   ↘           ↙
                             publish-image (imagetools create)
```