### PR TITLE
feat: implement ADR 0004 operator feature parity

### DIFF
--- a/api/v1alpha1/runebenchmark_types.go
+++ b/api/v1alpha1/runebenchmark_types.go
@@ -33,6 +33,11 @@ type RuneBenchmarkSpec struct {
 	MaxDPH             float64 `json:"maxDph,omitempty"`
 	Reliability        float64 `json:"reliability,omitempty"`
 	VastAIStopInstance bool    `json:"vastaiStopInstance,omitempty"`
+
+	// Agent to run for agentic-agent workflow (e.g. holmes, k8sgpt)
+	Agent string `json:"agent,omitempty"`
+	// When true, demands SLSA L3 signed provenance before execution
+	AttestationRequired bool `json:"attestationRequired,omitempty"`
 }
 
 type RunRecord struct {

--- a/api/v1alpha1/types_and_deepcopy_test.go
+++ b/api/v1alpha1/types_and_deepcopy_test.go
@@ -29,7 +29,7 @@ func TestAddToSchemeAndDeepCopy(t *testing.T) {
 	success := metav1.NewTime(time.Now().UTC())
 	rb := &RuneBenchmark{
 		ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: "ns"},
-		Spec:       RuneBenchmarkSpec{Workflow: "wf", Question: "q"},
+		Spec:       RuneBenchmarkSpec{Workflow: "wf", Question: "q", Agent: "holmes", AttestationRequired: true},
 
 		Status: RuneBenchmarkStatus{
 			LastScheduleTime:   &now,
@@ -43,6 +43,12 @@ func TestAddToSchemeAndDeepCopy(t *testing.T) {
 	copyRB := rb.DeepCopy()
 	if copyRB == nil || copyRB.Name != rb.Name || copyRB.Status.LastRun.RunID != "id" {
 		t.Fatalf("unexpected deep copy result: %+v", copyRB)
+	}
+	if copyRB.Spec.Agent != "holmes" {
+		t.Fatalf("expected Agent to be copied, got %q", copyRB.Spec.Agent)
+	}
+	if !copyRB.Spec.AttestationRequired {
+		t.Fatalf("expected AttestationRequired to be copied as true")
 	}
 
 	obj := rb.DeepCopyObject()

--- a/config/crd/bases/bench.rune.ai_runebenchmarks.yaml
+++ b/config/crd/bases/bench.rune.ai_runebenchmarks.yaml
@@ -106,6 +106,12 @@ spec:
                 vastaiStopInstance:
                   type: boolean
                   description: Stop the Vast.ai instance after the benchmark completes (benchmark only)
+                agent:
+                  description: Agent to run for agentic-agent workflow (e.g. holmes, k8sgpt)
+                  type: string
+                attestationRequired:
+                  description: When true, demands SLSA L3 signed provenance before execution
+                  type: boolean
             status:
               type: object
               properties:

--- a/config/samples/bench_v1alpha1_runebenchmark.yaml
+++ b/config/samples/bench_v1alpha1_runebenchmark.yaml
@@ -16,3 +16,5 @@ spec:
   timeoutSeconds: 180
   backoffSeconds: 60
   suspend: false
+  agent: "holmes"
+  attestationRequired: false

--- a/controllers/reconciler_and_http_test.go
+++ b/controllers/reconciler_and_http_test.go
@@ -752,3 +752,328 @@ func TestUpsertConditionAndCronError(t *testing.T) {
 		t.Fatalf("expected parse error for invalid cron")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Cost estimation pre-flight gate tests
+// ---------------------------------------------------------------------------
+
+func TestEstimatesPreflightSuccess(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/estimates" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"confidence_score":0.99}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"job_id":"job-est-ok"}`))
+	}))
+	defer ts.Close()
+
+	obj := &benchv1alpha1.RuneBenchmark{
+		ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: "ns", Generation: 1},
+		Spec: benchv1alpha1.RuneBenchmarkSpec{
+			APIBaseURL:   ts.URL,
+			Workflow:     "benchmark",
+			VastAI:       true,
+			TemplateHash: "tpl",
+			MinDPH:       0.1,
+			MaxDPH:       0.5,
+			Reliability:  0.95,
+		},
+	}
+	r, _ := buildReconciler(t, obj)
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "rb"}})
+	if err != nil {
+		t.Fatalf("expected reconcile to succeed, got %v", err)
+	}
+	if res.RequeueAfter == 0 {
+		t.Fatalf("expected requeue after success")
+	}
+
+	updated := &benchv1alpha1.RuneBenchmark{}
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "rb"}, updated); err != nil {
+		t.Fatalf("fetch updated object: %v", err)
+	}
+	if updated.Status.LastRun.Status != "succeeded" {
+		t.Fatalf("expected succeeded, got %q", updated.Status.LastRun.Status)
+	}
+}
+
+func TestEstimatesPreflightBelowThreshold(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/estimates" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"confidence_score":0.80}`))
+			return
+		}
+		t.Fatal("job endpoint should not be reached")
+	}))
+	defer ts.Close()
+
+	obj := &benchv1alpha1.RuneBenchmark{
+		ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: "ns", Generation: 1},
+		Spec: benchv1alpha1.RuneBenchmarkSpec{
+			APIBaseURL:     ts.URL,
+			Workflow:       "benchmark",
+			VastAI:         true,
+			BackoffSeconds: 10,
+		},
+	}
+	r, _ := buildReconciler(t, obj)
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "rb"}})
+	if err != nil {
+		t.Fatalf("reconcile should return nil error, got %v", err)
+	}
+	if res.RequeueAfter != 10*time.Second {
+		t.Fatalf("expected backoff requeue 10s, got %v", res.RequeueAfter)
+	}
+
+	updated := &benchv1alpha1.RuneBenchmark{}
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "rb"}, updated); err != nil {
+		t.Fatalf("fetch updated: %v", err)
+	}
+	if updated.Status.LastRun.Status != "failed" {
+		t.Fatalf("expected failed, got %q", updated.Status.LastRun.Status)
+	}
+	if !strings.Contains(updated.Status.LastRun.Error, "confidence") {
+		t.Fatalf("expected confidence error in last run, got %q", updated.Status.LastRun.Error)
+	}
+}
+
+func TestEstimatesPreflightHTTPError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/estimates" {
+			http.Error(w, "internal", http.StatusInternalServerError)
+			return
+		}
+		t.Fatal("job endpoint should not be reached")
+	}))
+	defer ts.Close()
+
+	obj := &benchv1alpha1.RuneBenchmark{
+		ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: "ns", Generation: 1},
+		Spec: benchv1alpha1.RuneBenchmarkSpec{
+			APIBaseURL:     ts.URL,
+			Workflow:       "benchmark",
+			VastAI:         true,
+			BackoffSeconds: 5,
+		},
+	}
+	r, _ := buildReconciler(t, obj)
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "rb"}})
+	if err != nil {
+		t.Fatalf("reconcile should return nil error, got %v", err)
+	}
+	if res.RequeueAfter != 5*time.Second {
+		t.Fatalf("expected backoff requeue 5s, got %v", res.RequeueAfter)
+	}
+
+	updated := &benchv1alpha1.RuneBenchmark{}
+	_ = r.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "rb"}, updated)
+	if updated.Status.LastRun.Status != "failed" {
+		t.Fatalf("expected failed, got %q", updated.Status.LastRun.Status)
+	}
+}
+
+func TestEstimatesPreflightParseError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/estimates" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("not-json"))
+			return
+		}
+		t.Fatal("job endpoint should not be reached")
+	}))
+	defer ts.Close()
+
+	obj := &benchv1alpha1.RuneBenchmark{
+		ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: "ns", Generation: 1},
+		Spec: benchv1alpha1.RuneBenchmarkSpec{
+			APIBaseURL:     ts.URL,
+			Workflow:       "benchmark",
+			VastAI:         true,
+			BackoffSeconds: 5,
+		},
+	}
+	r, _ := buildReconciler(t, obj)
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "rb"}})
+	if err != nil {
+		t.Fatalf("reconcile should return nil error, got %v", err)
+	}
+	if res.RequeueAfter != 5*time.Second {
+		t.Fatalf("expected backoff, got %v", res.RequeueAfter)
+	}
+
+	updated := &benchv1alpha1.RuneBenchmark{}
+	_ = r.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "rb"}, updated)
+	if !strings.Contains(updated.Status.LastRun.Error, "parse response") {
+		t.Fatalf("expected parse error, got %q", updated.Status.LastRun.Error)
+	}
+}
+
+func TestEstimatesSkippedForLocalWorkflow(t *testing.T) {
+	estimatesCalled := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/estimates" {
+			estimatesCalled = true
+			t.Fatal("estimates should not be called when VastAI is false")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"job_id":"job-local"}`))
+	}))
+	defer ts.Close()
+
+	obj := &benchv1alpha1.RuneBenchmark{
+		ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: "ns", Generation: 1},
+		Spec: benchv1alpha1.RuneBenchmarkSpec{
+			APIBaseURL: ts.URL,
+			Workflow:   "benchmark",
+			VastAI:     false,
+		},
+	}
+	r, _ := buildReconciler(t, obj)
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "rb"}})
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if estimatesCalled {
+		t.Fatal("estimates endpoint should not be called when VastAI is false")
+	}
+}
+
+func TestBuildPayloadAgenticAgentWithAgent(t *testing.T) {
+	spec := benchv1alpha1.RuneBenchmarkSpec{
+		Workflow: "agentic-agent",
+		Agent:    "holmes",
+	}
+	p := buildPayload(spec)
+	if p["agent"] != "holmes" {
+		t.Fatalf("expected agent=holmes, got %v", p["agent"])
+	}
+}
+
+func TestBuildPayloadAgenticAgentWithoutAgent(t *testing.T) {
+	spec := benchv1alpha1.RuneBenchmarkSpec{
+		Workflow: "agentic-agent",
+	}
+	p := buildPayload(spec)
+	if _, ok := p["agent"]; ok {
+		t.Fatalf("expected agent key to be omitted when empty, got %v", p["agent"])
+	}
+}
+
+func TestBuildPayloadBenchmarkWithAttestationRequired(t *testing.T) {
+	spec := benchv1alpha1.RuneBenchmarkSpec{
+		Workflow:            "benchmark",
+		AttestationRequired: true,
+	}
+	p := buildPayload(spec)
+	if p["attestation_required"] != true {
+		t.Fatalf("expected attestation_required=true, got %v", p["attestation_required"])
+	}
+}
+
+func TestBuildPayloadBenchmarkWithAttestationRequiredFalse(t *testing.T) {
+	spec := benchv1alpha1.RuneBenchmarkSpec{
+		Workflow:            "benchmark",
+		AttestationRequired: false,
+	}
+	p := buildPayload(spec)
+	if p["attestation_required"] != false {
+		t.Fatalf("expected attestation_required=false, got %v", p["attestation_required"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// checkCostEstimate unit tests (direct function calls)
+// ---------------------------------------------------------------------------
+
+func TestCheckCostEstimateSkipsWhenVastAIFalse(t *testing.T) {
+	spec := benchv1alpha1.RuneBenchmarkSpec{VastAI: false}
+	if err := checkCostEstimate(context.Background(), "http://unused", spec, http.DefaultClient, ""); err != nil {
+		t.Fatalf("expected nil for non-VastAI, got %v", err)
+	}
+}
+
+func TestCheckCostEstimateMarshalError(t *testing.T) {
+	oldMarshal := jsonMarshal
+	t.Cleanup(func() { jsonMarshal = oldMarshal })
+	jsonMarshal = func(any) ([]byte, error) { return nil, errors.New("marshal-boom") }
+
+	spec := benchv1alpha1.RuneBenchmarkSpec{VastAI: true}
+	err := checkCostEstimate(context.Background(), "http://unused", spec, http.DefaultClient, "")
+	if err == nil || !strings.Contains(err.Error(), "marshal") {
+		t.Fatalf("expected marshal error, got %v", err)
+	}
+}
+
+func TestCheckCostEstimateBadURL(t *testing.T) {
+	spec := benchv1alpha1.RuneBenchmarkSpec{VastAI: true}
+	err := checkCostEstimate(context.Background(), "://bad", spec, http.DefaultClient, "")
+	if err == nil || !strings.Contains(err.Error(), "build request") {
+		t.Fatalf("expected build request error, got %v", err)
+	}
+}
+
+func TestCheckCostEstimateTransportError(t *testing.T) {
+	spec := benchv1alpha1.RuneBenchmarkSpec{VastAI: true}
+	err := checkCostEstimate(context.Background(), "http://127.0.0.1:1", spec, &http.Client{Timeout: 100 * time.Millisecond}, "")
+	if err == nil || !strings.Contains(err.Error(), "HTTP request failed") {
+		t.Fatalf("expected transport error, got %v", err)
+	}
+}
+
+func TestCheckCostEstimateBodyReadError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "no hijack", http.StatusInternalServerError)
+			return
+		}
+		conn, buf, _ := hj.Hijack()
+		_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n")
+		_ = buf.Flush()
+		_ = conn.Close()
+	}))
+	defer ts.Close()
+
+	spec := benchv1alpha1.RuneBenchmarkSpec{VastAI: true}
+	err := checkCostEstimate(context.Background(), ts.URL, spec, http.DefaultClient, "")
+	if err == nil || !strings.Contains(err.Error(), "read response") {
+		t.Fatalf("expected read response error, got %v", err)
+	}
+}
+
+func TestCheckCostEstimateSendsAuthHeader(t *testing.T) {
+	var gotAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"confidence_score":0.99}`))
+	}))
+	defer ts.Close()
+
+	spec := benchv1alpha1.RuneBenchmarkSpec{VastAI: true}
+	err := checkCostEstimate(context.Background(), ts.URL, spec, http.DefaultClient, "my-token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotAuth != "Bearer my-token" {
+		t.Fatalf("expected auth header, got %q", gotAuth)
+	}
+}
+
+func TestCheckCostEstimateExactThreshold(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"confidence_score":0.95}`))
+	}))
+	defer ts.Close()
+
+	spec := benchv1alpha1.RuneBenchmarkSpec{VastAI: true}
+	err := checkCostEstimate(context.Background(), ts.URL, spec, http.DefaultClient, "")
+	if err != nil {
+		t.Fatalf("expected 0.95 to pass threshold, got %v", err)
+	}
+}

--- a/controllers/runebenchmark_controller.go
+++ b/controllers/runebenchmark_controller.go
@@ -160,7 +160,7 @@ func (r *RuneBenchmarkReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 func buildPayload(spec benchv1alpha1.RuneBenchmarkSpec) map[string]any {
 	switch spec.Workflow {
 	case "agentic-agent":
-		return map[string]any{
+		p := map[string]any{
 			"question":              spec.Question,
 			"model":                 spec.Model,
 			"ollama_url":            spec.OllamaURL,
@@ -168,6 +168,10 @@ func buildPayload(spec benchv1alpha1.RuneBenchmarkSpec) map[string]any {
 			"ollama_warmup_timeout": int(spec.OllamaWarmupTimeoutSeconds),
 			"kubeconfig":            spec.Kubeconfig,
 		}
+		if spec.Agent != "" {
+			p["agent"] = spec.Agent
+		}
+		return p
 	case "ollama-instance":
 		return map[string]any{
 			"vastai":        spec.VastAI,
@@ -191,6 +195,7 @@ func buildPayload(spec benchv1alpha1.RuneBenchmarkSpec) map[string]any {
 			"ollama_warmup_timeout": int(spec.OllamaWarmupTimeoutSeconds),
 			"kubeconfig":            spec.Kubeconfig,
 			"vastai_stop_instance":  spec.VastAIStopInstance,
+			"attestation_required":  spec.AttestationRequired,
 		}
 	default:
 		// Unknown workflow kind — forward what we have; the API server will reject with a clear error.
@@ -201,6 +206,69 @@ func buildPayload(spec benchv1alpha1.RuneBenchmarkSpec) map[string]any {
 			"ollama_url": spec.OllamaURL,
 		}
 	}
+}
+
+// estimateConfidenceThreshold is the minimum confidence score required from the
+// cost estimation endpoint before a VastAI job may proceed.
+const estimateConfidenceThreshold = 0.95
+
+// estimateResponse is the expected JSON structure from POST /v1/estimates.
+type estimateResponse struct {
+	ConfidenceScore float64 `json:"confidence_score"`
+}
+
+// checkCostEstimate performs a fail-closed pre-flight cost estimation gate.
+// When VastAI is enabled, it calls the /v1/estimates endpoint and verifies
+// confidence >= 0.95. Any HTTP or parse error halts reconciliation.
+func checkCostEstimate(ctx context.Context, apiBase string, spec benchv1alpha1.RuneBenchmarkSpec, httpClient *http.Client, token string) error {
+	if !spec.VastAI {
+		return nil
+	}
+
+	estimatePayload := map[string]any{
+		"template_hash": spec.TemplateHash,
+		"min_dph":       spec.MinDPH,
+		"max_dph":       spec.MaxDPH,
+		"reliability":   spec.Reliability,
+	}
+	body, err := jsonMarshal(estimatePayload)
+	if err != nil {
+		return fmt.Errorf("cost estimate: failed to marshal request: %w", err)
+	}
+
+	url := strings.TrimRight(apiBase, "/") + "/v1/estimates"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("cost estimate: failed to build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("cost estimate: HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("cost estimate: failed to read response: %w", err)
+	}
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("cost estimate: API returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var parsed estimateResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return fmt.Errorf("cost estimate: failed to parse response: %w", err)
+	}
+	if parsed.ConfidenceScore < estimateConfidenceThreshold {
+		return fmt.Errorf("cost estimate: confidence %.2f below threshold %.2f", parsed.ConfidenceScore, estimateConfidenceThreshold)
+	}
+
+	return nil
 }
 
 func (r *RuneBenchmarkReconciler) executeBenchmark(ctx context.Context, obj *benchv1alpha1.RuneBenchmark, timeout time.Duration) (benchv1alpha1.RunRecord, error) {
@@ -236,6 +304,11 @@ func (r *RuneBenchmarkReconciler) executeBenchmark(ctx context.Context, obj *ben
 	if tokenErr != nil {
 		return record, tokenErr
 	}
+
+	if err := checkCostEstimate(ctx, obj.Spec.APIBaseURL, obj.Spec, clientHTTP, token); err != nil {
+		return record, err
+	}
+
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}


### PR DESCRIPTION
## Summary

- Adds `Agent` and `AttestationRequired` fields to RuneBenchmarkSpec CRD
- Implements fail-closed cost estimation gate (`POST /v1/estimates`, confidence >= 0.95)
- 16 new tests, 100% coverage

Closes #31

## DoD Level

- [x] **Level 1** — Full Validation
- [ ] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation

## Acceptance Criteria Evidence

- gofmt clean, go vet clean, 100% statement coverage
- CRD YAML updated and copied to rune-charts

## Audit Checks

cyber check:api — CRD schema changed. PASS — additive fields only.

## Breaking Changes

None — additive CRD fields with omitempty.