### PR TITLE
Block GPL-2.0 variants in license gate

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -408,6 +408,8 @@ jobs:
               'gnu affero general public license',
               'gplv2',
               'gpl v2',
+              'gpl-2.0-only',
+              'gpl-2.0-or-later',
               'gpl-2.0',
               'gnu general public license v2',
           )


### PR DESCRIPTION
## Summary

- Adds `GPL-2.0-only` and `GPL-2.0-or-later` SPDX identifiers to the `disallowed_tokens` list in the `security-licenses` CI job
- Aligns with the reference implementation in `rune-docs` which uses explicit SPDX blocked IDs
- Ensures `go-licenses` output using SPDX short identifiers is caught alongside existing alias tokens (`gplv2`, `gpl v2`, `gpl-2.0`, etc.)

Closes #42

## Definition of Done

- [ ] **Level 1** (runtime behavior, APIs, drivers, backends, agents, Helm, Docker)
- [x] **Level 2** (test infrastructure, CI workflows, coverage, linter configs, dev tooling)
- [ ] **Level 3** (documentation only)

## Acceptance Criteria Evidence

- **YAML validation**: `python3 -c "import yaml; yaml.safe_load(open(...))"` passes — confirmed locally
- **Token ordering**: `gpl-2.0-only` and `gpl-2.0-or-later` placed before the generic `gpl-2.0` token for readability; substring matching ensures all variants are caught regardless of order
- **Reference alignment**: Matches `rune-docs` `quality-gates.yml` blocked SPDX IDs (`GPL-2.0-ONLY`, `GPL-2.0-OR-LATER`)

## Audit Checks

| Trigger | Check | Result |
|---|---|---|
| CI workflow modified | `cyber check:supply-chain` | PASS — change is additive (two new string literals in an existing blocked-license list); no new tools, actions, or permissions introduced |

## Breaking Changes

None. This is a strictly additive change to the license blocklist. No existing allowed licenses are affected.