### PR TITLE
fix: standardize copyright year to 2025-2026

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
 rune-operator
-Copyright 2025 The Rune Authors
+Copyright 2025-2026 The Rune Authors
 
 This product is licensed under the Apache License, Version 2.0.


### PR DESCRIPTION
## Summary
- Update NOTICE copyright from `2025` to `2025-2026` to match all other repos

Closes #70

## DoD Level

- [ ] **Level 1** — Full Validation
- [ ] **Level 2** — Test Infrastructure
- [x] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- [x] NOTICE file copyright year matches all other repos (`2025-2026`)

## Audit Checks

No triggers fired — metadata-only change.

## Breaking Changes

None.

## Test plan

- [x] `grep "Copyright" NOTICE` shows `2025-2026`

🤖 Generated with [Claude Code](https://claude.com/claude-code)