### PR TITLE
feat: add backend_type field to CRD and payloads

### DIFF
--- a/api/v1alpha1/runebenchmark_types.go
+++ b/api/v1alpha1/runebenchmark_types.go
@@ -13,6 +13,9 @@ type RuneBenchmarkSpec struct {
 	Question          string `json:"question,omitempty"`
 	Model             string `json:"model,omitempty"`
 	BackendURL        string `json:"backendUrl,omitempty"`
+	// BackendType is the LLM backend type (e.g., "ollama", "k8s-inference").
+	// +kubebuilder:default="ollama"
+	BackendType       string `json:"backendType,omitempty"`
 	InsecureTLS       bool   `json:"insecureTls,omitempty"`
 	Schedule          string `json:"schedule,omitempty"`
 	Suspend           bool   `json:"suspend,omitempty"`

--- a/api/v1alpha1/runebenchmark_types.go
+++ b/api/v1alpha1/runebenchmark_types.go
@@ -15,12 +15,12 @@ type RuneBenchmarkSpec struct {
 	BackendURL        string `json:"backendUrl,omitempty"`
 	// BackendType is the LLM backend type (e.g., "ollama", "k8s-inference").
 	// +kubebuilder:default="ollama"
-	BackendType       string `json:"backendType,omitempty"`
-	InsecureTLS       bool   `json:"insecureTls,omitempty"`
-	Schedule          string `json:"schedule,omitempty"`
-	Suspend           bool   `json:"suspend,omitempty"`
-	TimeoutSeconds    int32  `json:"timeoutSeconds,omitempty"`
-	BackoffSeconds    int32  `json:"backoffSeconds,omitempty"`
+	BackendType    string `json:"backendType,omitempty"`
+	InsecureTLS    bool   `json:"insecureTls,omitempty"`
+	Schedule       string `json:"schedule,omitempty"`
+	Suspend        bool   `json:"suspend,omitempty"`
+	TimeoutSeconds int32  `json:"timeoutSeconds,omitempty"`
+	BackoffSeconds int32  `json:"backoffSeconds,omitempty"`
 
 	// Backend warmup options (agentic-agent, benchmark)
 	BackendWarmup               bool  `json:"backendWarmup,omitempty"`

--- a/config/crd/bases/bench.rune.ai_runebenchmarks.yaml
+++ b/config/crd/bases/bench.rune.ai_runebenchmarks.yaml
@@ -63,6 +63,11 @@ spec:
               attestationRequired:
                 description: When true, demands SLSA L3 signed provenance before execution
                 type: boolean
+              backendType:
+                default: ollama
+                description: BackendType is the LLM backend type (e.g., "ollama",
+                  "k8s-inference").
+                type: string
               backendUrl:
                 type: string
               backendWarmup:

--- a/config/samples/bench_v1alpha1_runebenchmark.yaml
+++ b/config/samples/bench_v1alpha1_runebenchmark.yaml
@@ -9,6 +9,7 @@ spec:
   question: "Why is the cluster degraded?"
   model: "llama3.1:8b"
   backendUrl: "http://ollama.default.svc.cluster.local:11434"
+  backendType: "ollama"
   backendWarmup: true
   backendWarmupTimeoutSeconds: 120
   kubeconfig: ""

--- a/controllers/reconciler_and_http_test.go
+++ b/controllers/reconciler_and_http_test.go
@@ -985,6 +985,31 @@ func TestBuildPayloadBenchmarkWithAttestationRequiredFalse(t *testing.T) {
 	}
 }
 
+func TestBuildPayloadBackendTypeNonDefault(t *testing.T) {
+	spec := benchv1alpha1.RuneBenchmarkSpec{
+		Workflow:    "agentic-agent",
+		BackendType: "k8s-inference",
+		Question:    "test",
+	}
+	p := buildPayload(spec)
+	if p["backend_type"] != "k8s-inference" {
+		t.Errorf("expected backend_type=k8s-inference, got %v", p["backend_type"])
+	}
+}
+
+func TestBuildPayloadBackendTypeInAllWorkflows(t *testing.T) {
+	for _, wf := range []string{"agentic-agent", "ollama-instance", "benchmark", "unknown"} {
+		spec := benchv1alpha1.RuneBenchmarkSpec{
+			Workflow:    wf,
+			BackendType: "ollama",
+		}
+		p := buildPayload(spec)
+		if p["backend_type"] != "ollama" {
+			t.Errorf("workflow %q: expected backend_type=ollama, got %v", wf, p["backend_type"])
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // checkCostEstimate unit tests (direct function calls)
 // ---------------------------------------------------------------------------

--- a/controllers/runebenchmark_controller.go
+++ b/controllers/runebenchmark_controller.go
@@ -164,6 +164,7 @@ func buildPayload(spec benchv1alpha1.RuneBenchmarkSpec) map[string]any {
 			"question":               spec.Question,
 			"model":                  spec.Model,
 			"backend_url":            spec.BackendURL,
+			"backend_type":           spec.BackendType,
 			"backend_warmup":         spec.BackendWarmup,
 			"backend_warmup_timeout": int(spec.BackendWarmupTimeoutSeconds),
 			"kubeconfig":             spec.Kubeconfig,
@@ -180,6 +181,7 @@ func buildPayload(spec benchv1alpha1.RuneBenchmarkSpec) map[string]any {
 			"max_dph":       spec.MaxDPH,
 			"reliability":   spec.Reliability,
 			"backend_url":   spec.BackendURL,
+			"backend_type":  spec.BackendType,
 		}
 	case "benchmark":
 		return map[string]any{
@@ -189,6 +191,7 @@ func buildPayload(spec benchv1alpha1.RuneBenchmarkSpec) map[string]any {
 			"max_dph":                spec.MaxDPH,
 			"reliability":            spec.Reliability,
 			"backend_url":            spec.BackendURL,
+			"backend_type":           spec.BackendType,
 			"question":               spec.Question,
 			"model":                  spec.Model,
 			"backend_warmup":         spec.BackendWarmup,
@@ -200,10 +203,11 @@ func buildPayload(spec benchv1alpha1.RuneBenchmarkSpec) map[string]any {
 	default:
 		// Unknown workflow kind — forward what we have; the API server will reject with a clear error.
 		return map[string]any{
-			"workflow":    spec.Workflow,
-			"question":    spec.Question,
-			"model":       spec.Model,
-			"backend_url": spec.BackendURL,
+			"workflow":     spec.Workflow,
+			"question":     spec.Question,
+			"model":        spec.Model,
+			"backend_url":  spec.BackendURL,
+			"backend_type": spec.BackendType,
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add `BackendType` field to `RuneBenchmarkSpec` with kubebuilder default `"ollama"`
- Include `"backend_type"` in all 4 payload branches of `buildPayload()`
- Add 2 new tests: non-default backend_type and all-workflows coverage
- Regenerate CRD manifest
- Update sample CR with `backendType: "ollama"`

Closes #61

## DoD Level

- [x] **Level 1** — Full Validation (CRD schema change)
- [ ] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- [x] `BackendType` field exists in `RuneBenchmarkSpec` with default `"ollama"`
- [x] `backend_type` key present in all 4 buildPayload() branches
- [x] CRD manifest has `backendType` with default
- [x] Sample CR updated
- [x] `go build ./...` succeeds
- [x] `go test ./... -count=1` passes (5/5 packages, 2 new tests)

## Audit Checks

| Check | Result |
|---|---|
| `cyber check:api` | PASS — additive CRD field with default value |

## Breaking Changes

None — additive field with default value.

## Test plan

- [x] `go test ./... -count=1` — all pass
- [x] `gofmt -l .` — clean
- [x] `grep "backendType" config/crd/bases/bench.rune.ai_runebenchmarks.yaml` — present

🤖 Generated with [Claude Code](https://claude.com/claude-code)