### PR TITLE
feat: add idempotency key support for job submissions

### DIFF
--- a/controllers/reconciler_and_http_test.go
+++ b/controllers/reconciler_and_http_test.go
@@ -1011,6 +1011,71 @@ func TestBuildPayloadBackendTypeInAllWorkflows(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Idempotency key tests
+// ---------------------------------------------------------------------------
+
+func TestIdempotencyKeyHeaderSent(t *testing.T) {
+	var gotKey string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			gotKey = r.Header.Get("Idempotency-Key")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"job_id":"job-idem","status":"succeeded"}`))
+	}))
+	defer ts.Close()
+
+	obj := &benchv1alpha1.RuneBenchmark{
+		ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: "ns", Generation: 3},
+		Spec: benchv1alpha1.RuneBenchmarkSpec{
+			APIBaseURL: ts.URL,
+			Workflow:   "agentic-agent",
+		},
+	}
+	r, _ := buildReconciler(t, obj)
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "rb"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotKey == "" {
+		t.Fatal("expected Idempotency-Key header to be set")
+	}
+	if !strings.Contains(gotKey, "ns/rb/3/") {
+		t.Fatalf("idempotency key should contain namespace/name/generation, got: %s", gotKey)
+	}
+}
+
+func TestIdempotencyKeyDeterministic(t *testing.T) {
+	var keys []string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			keys = append(keys, r.Header.Get("Idempotency-Key"))
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"job_id":"job-det","status":"succeeded"}`))
+	}))
+	defer ts.Close()
+
+	obj := &benchv1alpha1.RuneBenchmark{
+		ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: "ns", Generation: 1},
+		Spec: benchv1alpha1.RuneBenchmarkSpec{
+			APIBaseURL: ts.URL,
+			Workflow:   "agentic-agent",
+		},
+	}
+	r, _ := buildReconciler(t, obj)
+	// Reconcile twice — same generation should produce same key
+	_, _ = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "rb"}})
+	_, _ = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "rb"}})
+	if len(keys) < 2 {
+		t.Fatalf("expected 2 keys, got %d", len(keys))
+	}
+	if keys[0] != keys[1] {
+		t.Fatalf("idempotency keys should be deterministic: %q vs %q", keys[0], keys[1])
+	}
+}
+
+// ---------------------------------------------------------------------------
 // checkCostEstimate unit tests (direct function calls)
 // ---------------------------------------------------------------------------
 

--- a/controllers/runebenchmark_controller.go
+++ b/controllers/runebenchmark_controller.go
@@ -304,6 +304,17 @@ func (r *RuneBenchmarkReconciler) executeBenchmark(ctx context.Context, obj *ben
 		req.Header.Set("X-Tenant-ID", obj.Spec.Tenant)
 	}
 
+	// Deterministic idempotency key: same resource + generation + schedule = same key.
+	// Retries of the same reconciliation produce the same key (safe retry).
+	// New generation or new schedule = new key (new job).
+	scheduleTime := ""
+	if obj.Status.LastScheduleTime != nil {
+		scheduleTime = obj.Status.LastScheduleTime.UTC().Format(time.RFC3339)
+	}
+	idempotencyKey := fmt.Sprintf("%s/%s/%d/%s",
+		obj.Namespace, obj.Name, obj.Generation, scheduleTime)
+	req.Header.Set("Idempotency-Key", idempotencyKey)
+
 	token, tokenErr := r.readToken(ctx, obj)
 	if tokenErr != nil {
 		return record, tokenErr


### PR DESCRIPTION
## Summary
- Generate deterministic `Idempotency-Key` header from `namespace/name/generation/lastScheduleTime`
- Retries of the same reconciliation produce the same key (safe retry)
- New generation or new schedule time = new key (new job)
- No CRD changes — entirely internal to the controller
- Add 2 tests: header presence and deterministic key generation

Closes #65

## DoD Level

- [x] **Level 1** — Full Validation (runtime behavior change)
- [ ] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- [x] `Idempotency-Key` header present in job submission requests
- [x] Key is deterministic: same resource/generation/schedule → same key
- [x] Key changes with new generation (verified by key format containing generation number)
- [x] All tests pass (5/5 packages)

## Audit Checks

No triggers fired — no CRD changes, no API endpoints changed, no dependencies added.

## Breaking Changes

None — additive header, API ignores unknown headers if not supported.

## Test plan

- [x] `go test ./... -count=1` — all 5 packages pass
- [x] `TestIdempotencyKeyHeaderSent` — verifies header is set with correct format
- [x] `TestIdempotencyKeyDeterministic` — verifies same reconciliation produces same key

🤖 Generated with [Claude Code](https://claude.com/claude-code)