### PR TITLE
feat: abstract cost estimation gate beyond Vast.ai

### DIFF
--- a/api/v1alpha1/runebenchmark_types.go
+++ b/api/v1alpha1/runebenchmark_types.go
@@ -42,10 +42,31 @@ type RuneBenchmarkSpec struct {
 	Reliability        float64 `json:"reliability,omitempty"`
 	VastAIStopInstance bool    `json:"vastaiStopInstance,omitempty"`
 
+	// CostEstimation configures the pre-flight cost safety gate.
+	CostEstimation CostEstimation `json:"costEstimation,omitempty"`
+
 	// Agent to run for agentic-agent workflow (e.g. holmes, k8sgpt)
 	Agent string `json:"agent,omitempty"`
 	// When true, demands SLSA L3 signed provenance before execution
 	AttestationRequired bool `json:"attestationRequired,omitempty"`
+}
+
+// CostEstimation configures the pre-flight cost gate.
+// At most one provider flag should be true. If none are set and VastAI provisioning
+// is enabled, the gate fires automatically for backward compatibility.
+type CostEstimation struct {
+	// Cloud providers
+	VastAI bool `json:"vastai,omitempty"`
+	AWS    bool `json:"aws,omitempty"`
+	GCP    bool `json:"gcp,omitempty"`
+	Azure  bool `json:"azure,omitempty"`
+
+	// Local hardware estimation
+	LocalHardware              bool    `json:"localHardware,omitempty"`
+	LocalTDPWatts              float64 `json:"localTdpWatts,omitempty"`
+	LocalEnergyRateKWH         float64 `json:"localEnergyRateKwh,omitempty"`
+	LocalHardwarePurchasePrice float64 `json:"localHardwarePurchasePrice,omitempty"`
+	LocalHardwareLifespanYears float64 `json:"localHardwareLifespanYears,omitempty"`
 }
 
 type RunRecord struct {

--- a/config/crd/bases/bench.rune.ai_runebenchmarks.yaml
+++ b/config/crd/bases/bench.rune.ai_runebenchmarks.yaml
@@ -79,6 +79,31 @@ spec:
               backoffSeconds:
                 format: int32
                 type: integer
+              costEstimation:
+                description: CostEstimation configures the pre-flight cost safety
+                  gate.
+                properties:
+                  aws:
+                    type: boolean
+                  azure:
+                    type: boolean
+                  gcp:
+                    type: boolean
+                  localEnergyRateKwh:
+                    type: number
+                  localHardware:
+                    description: Local hardware estimation
+                    type: boolean
+                  localHardwareLifespanYears:
+                    type: number
+                  localHardwarePurchasePrice:
+                    type: number
+                  localTdpWatts:
+                    type: number
+                  vastai:
+                    description: Cloud providers
+                    type: boolean
+                type: object
               insecureTls:
                 type: boolean
               kubeconfig:

--- a/controllers/reconciler_and_http_test.go
+++ b/controllers/reconciler_and_http_test.go
@@ -1477,6 +1477,81 @@ func TestCheckCostEstimateSkipsWhenVastAIFalse(t *testing.T) {
 	}
 }
 
+func TestCheckCostEstimateSkipsWhenNoCostProvider(t *testing.T) {
+	// No VastAI, no CostEstimation providers → skip
+	spec := benchv1alpha1.RuneBenchmarkSpec{VastAI: false}
+	if err := checkCostEstimate(context.Background(), "http://unused", spec, http.DefaultClient, ""); err != nil {
+		t.Fatalf("expected nil when no providers, got %v", err)
+	}
+}
+
+func TestCheckCostEstimateFiresForAWS(t *testing.T) {
+	var gotPayload map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotPayload)
+		_, _ = w.Write([]byte(`{"confidence_score":0.99}`))
+	}))
+	defer ts.Close()
+
+	spec := benchv1alpha1.RuneBenchmarkSpec{
+		CostEstimation: benchv1alpha1.CostEstimation{AWS: true},
+		Model:          "llama3",
+		TimeoutSeconds: 300,
+	}
+	if err := checkCostEstimate(context.Background(), ts.URL, spec, http.DefaultClient, ""); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if gotPayload["aws"] != true {
+		t.Fatal("expected aws=true in payload")
+	}
+	if gotPayload["model"] != "llama3" {
+		t.Fatalf("expected model=llama3, got %v", gotPayload["model"])
+	}
+}
+
+func TestCheckCostEstimateFiresForLocalHardware(t *testing.T) {
+	var gotPayload map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotPayload)
+		_, _ = w.Write([]byte(`{"confidence_score":0.99}`))
+	}))
+	defer ts.Close()
+
+	spec := benchv1alpha1.RuneBenchmarkSpec{
+		CostEstimation: benchv1alpha1.CostEstimation{
+			LocalHardware: true,
+			LocalTDPWatts: 350,
+		},
+	}
+	if err := checkCostEstimate(context.Background(), ts.URL, spec, http.DefaultClient, ""); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if gotPayload["local_hardware"] != true {
+		t.Fatal("expected local_hardware=true")
+	}
+	if gotPayload["local_tdp_watts"] != 350.0 {
+		t.Fatalf("expected local_tdp_watts=350, got %v", gotPayload["local_tdp_watts"])
+	}
+}
+
+func TestCheckCostEstimateBackwardCompat(t *testing.T) {
+	// spec.VastAI=true with empty CostEstimation → gate fires
+	called := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		_, _ = w.Write([]byte(`{"confidence_score":0.99}`))
+	}))
+	defer ts.Close()
+
+	spec := benchv1alpha1.RuneBenchmarkSpec{VastAI: true}
+	if err := checkCostEstimate(context.Background(), ts.URL, spec, http.DefaultClient, ""); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if !called {
+		t.Fatal("cost gate should fire when VastAI=true even without explicit CostEstimation")
+	}
+}
+
 func TestCheckCostEstimateMarshalError(t *testing.T) {
 	oldMarshal := jsonMarshal
 	t.Cleanup(func() { jsonMarshal = oldMarshal })

--- a/controllers/runebenchmark_controller.go
+++ b/controllers/runebenchmark_controller.go
@@ -277,18 +277,42 @@ func maxInt32(a, b int32) int32 {
 }
 
 // checkCostEstimate performs a fail-closed pre-flight cost estimation gate.
-// When VastAI is enabled, it calls the /v1/estimates endpoint and verifies
-// confidence >= 0.95. Any HTTP or parse error halts reconciliation.
+// If any cost provider is enabled (VastAI, AWS, GCP, Azure, LocalHardware),
+// it calls the /v1/estimates endpoint and verifies confidence >= 0.95.
+// For backward compatibility, if no explicit cost estimation is configured but
+// spec.VastAI is true, the gate fires automatically.
 func checkCostEstimate(ctx context.Context, apiBase string, spec benchv1alpha1.RuneBenchmarkSpec, httpClient *http.Client, token string) error {
-	if !spec.VastAI {
-		return nil
+	ce := spec.CostEstimation
+
+	// Backward compat: if no explicit costEstimation but vastai provisioning is on, gate it
+	if !ce.VastAI && !ce.AWS && !ce.GCP && !ce.Azure && !ce.LocalHardware {
+		if spec.VastAI {
+			ce.VastAI = true
+		} else {
+			return nil
+		}
 	}
 
 	estimatePayload := map[string]any{
+		// Provider flags
+		"vastai":         ce.VastAI,
+		"aws":            ce.AWS,
+		"gcp":            ce.GCP,
+		"azure":          ce.Azure,
+		"local_hardware": ce.LocalHardware,
+		// Price bounds
 		"template_hash": spec.TemplateHash,
 		"min_dph":       spec.MinDPH,
 		"max_dph":       spec.MaxDPH,
 		"reliability":   spec.Reliability,
+		// Local hardware params
+		"local_tdp_watts":               ce.LocalTDPWatts,
+		"local_energy_rate_kwh":         ce.LocalEnergyRateKWH,
+		"local_hardware_purchase_price": ce.LocalHardwarePurchasePrice,
+		"local_hardware_lifespan_years": ce.LocalHardwareLifespanYears,
+		// Run context
+		"model":                      spec.Model,
+		"estimated_duration_seconds": int(spec.TimeoutSeconds),
 	}
 	body, err := jsonMarshal(estimatePayload)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add `CostEstimation` struct to CRD: VastAI, AWS, GCP, Azure, LocalHardware (with TDP/energy params)
- Cost gate fires for any enabled provider, not just VastAI
- Backward compat: `spec.vastai=true` with empty `costEstimation` auto-fires gate
- Expanded payload includes all provider flags, local hardware params, model, duration
- 4 new tests, CRD regenerated

Closes #64

## DoD Level

- [x] **Level 1** — Full Validation (CRD schema change)
- [ ] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- [x] `CostEstimation` struct in CRD with all provider fields
- [x] Gate fires for AWS, GCP, Azure, LocalHardware (not just VastAI)
- [x] Backward compat: `spec.vastai=true` auto-fires gate
- [x] Full payload sent to `/v1/estimates`
- [x] All tests pass (5/5 packages)

## Audit Checks

| Check | Result |
|---|---|
| `cyber check:api` | PASS — additive CRD struct, backward-compatible gate logic |

## Breaking Changes

None — additive struct with backward-compatible behavior.

## Test plan

- [x] `go test ./... -count=1` — all pass
- [x] `gofmt -l .` — clean
- [x] 4 new tests: no-provider skip, AWS, LocalHardware, backward compat

🤖 Generated with [Claude Code](https://claude.com/claude-code)