### PR TITLE
feat: store job results in RuneBenchmark status

### DIFF
--- a/api/v1alpha1/runebenchmark_types.go
+++ b/api/v1alpha1/runebenchmark_types.go
@@ -55,6 +55,9 @@ type RunRecord struct {
 	DurationMillis int64       `json:"durationMillis,omitempty"`
 	Status         string      `json:"status,omitempty"`
 	Error          string      `json:"error,omitempty"`
+	// Result contains the job output as a raw JSON string.
+	// +optional
+	Result string `json:"result,omitempty"`
 }
 
 type RuneBenchmarkStatus struct {

--- a/config/crd/bases/bench.rune.ai_runebenchmarks.yaml
+++ b/config/crd/bases/bench.rune.ai_runebenchmarks.yaml
@@ -91,6 +91,13 @@ spec:
                 type: number
               model:
                 type: string
+              pollIntervalSeconds:
+                description: PollIntervalSeconds is the interval between job status
+                  polls (default 5).
+                format: int32
+                maximum: 60
+                minimum: 2
+                type: integer
               question:
                 type: string
               reliability:
@@ -189,6 +196,9 @@ spec:
                       type: integer
                     error:
                       type: string
+                    result:
+                      description: Result contains the job output as a raw JSON string.
+                      type: string
                     runId:
                       type: string
                     status:
@@ -207,6 +217,9 @@ spec:
                     format: int64
                     type: integer
                   error:
+                    type: string
+                  result:
+                    description: Result contains the job output as a raw JSON string.
                     type: string
                   runId:
                     type: string

--- a/controllers/reconciler_and_http_test.go
+++ b/controllers/reconciler_and_http_test.go
@@ -1343,6 +1343,69 @@ func TestPollTransientError(t *testing.T) {
 	}
 }
 
+func TestPollCapturesResult(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"job_id":"j-res"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"succeeded","result":{"answer":"Pod OOM killed"}}`))
+	}))
+	defer ts.Close()
+
+	obj := &benchv1alpha1.RuneBenchmark{
+		ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: "ns", Generation: 1},
+		Spec: benchv1alpha1.RuneBenchmarkSpec{
+			APIBaseURL:          ts.URL,
+			Workflow:            "agentic-agent",
+			PollIntervalSeconds: 2,
+		},
+	}
+	rec, _ := buildReconciler(t, obj)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, _ = rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "rb"}})
+	updated := &benchv1alpha1.RuneBenchmark{}
+	_ = rec.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "rb"}, updated)
+	if updated.Status.LastRun.Result == "" {
+		t.Fatal("expected result to be captured")
+	}
+	if !strings.Contains(updated.Status.LastRun.Result, "Pod OOM killed") {
+		t.Fatalf("result should contain answer: %s", updated.Status.LastRun.Result)
+	}
+}
+
+func TestPollNoResultField(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"job_id":"j-nores"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"succeeded"}`))
+	}))
+	defer ts.Close()
+
+	obj := &benchv1alpha1.RuneBenchmark{
+		ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: "ns", Generation: 1},
+		Spec: benchv1alpha1.RuneBenchmarkSpec{
+			APIBaseURL:          ts.URL,
+			Workflow:            "agentic-agent",
+			PollIntervalSeconds: 2,
+		},
+	}
+	rec, _ := buildReconciler(t, obj)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, _ = rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "rb"}})
+	updated := &benchv1alpha1.RuneBenchmark{}
+	_ = rec.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "rb"}, updated)
+	if updated.Status.LastRun.Result != "" {
+		t.Fatalf("expected empty result, got: %s", updated.Status.LastRun.Result)
+	}
+}
+
 func TestPollSkippedWhenNoJobID(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {

--- a/controllers/runebenchmark_controller.go
+++ b/controllers/runebenchmark_controller.go
@@ -226,9 +226,10 @@ type estimateResponse struct {
 
 // jobStatusResponse is the expected JSON from GET /v1/jobs/{job_id}.
 type jobStatusResponse struct {
-	Status  string `json:"status"`
-	Error   string `json:"error,omitempty"`
-	Message string `json:"message,omitempty"`
+	Status  string          `json:"status"`
+	Error   string          `json:"error,omitempty"`
+	Message string          `json:"message,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
 }
 
 // getJobStatus polls the Rune API for the actual status of a submitted job.
@@ -433,6 +434,9 @@ func (r *RuneBenchmarkReconciler) executeBenchmark(ctx context.Context, obj *ben
 		switch status.Status {
 		case "succeeded", "success", "completed":
 			record.Status = "succeeded"
+			if len(status.Result) > 0 {
+				record.Result = string(status.Result)
+			}
 			return record, nil
 		case "failed", "error":
 			record.Status = "failed"


### PR DESCRIPTION
## Summary
- Add `Result` field (raw JSON string) to `RunRecord` in CRD
- Capture job output from poll response on successful completion
- Extend `jobStatusResponse` with `json.RawMessage` Result field
- Add 2 tests: result captured, and empty when no result
- Regenerate CRD manifest

Closes #63

## DoD Level

- [x] **Level 1** — Full Validation (CRD schema change)
- [ ] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- [x] `RunRecord.Result` field exists as raw JSON string
- [x] Result captured from poll response on success
- [x] Result empty when poll response has no result field
- [x] All tests pass (5/5 packages)
- [x] CRD manifest regenerated with `result` field

## Audit Checks

| Check | Result |
|---|---|
| `cyber check:api` | PASS — additive CRD field, no breaking changes |

## Breaking Changes

None — additive field.

## Test plan

- [x] `go test ./... -count=1` — all pass
- [x] `TestPollCapturesResult` — verifies result stored in status
- [x] `TestPollNoResultField` — verifies empty when absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)