### PR TITLE
ci: standardize project-sync to rune-ci reusable workflow

### DIFF
--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -3,13 +3,12 @@ name: Project Board Sync
 
 on:
   issues:
-    types: [opened, closed, reopened, labeled, unlabeled]
+    types: [opened, closed, reopened, labeled, unlabeled, assigned, unassigned]
   pull_request:
-    types: [opened, closed, reopened, ready_for_review, converted_to_draft, labeled, unlabeled]
+    types: [opened, closed, reopened, ready_for_review, converted_to_draft, labeled, unlabeled, synchronized]
 
 jobs:
   sync:
-    uses: lpasquali/rune-ci/.github/workflows/project-sync.yml@b242495fb92b046879c9e0ecb8e88a0e89e0e7d5 # main
+    uses: lpasquali/rune-ci/.github/workflows/project-sync-logic.yml@063ed73b40bf986310a32ee32dc8e21e0a39aa55 # main
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
-


### PR DESCRIPTION
## Summary
- Replace inline/outdated project-sync callers with `project-sync-logic.yml@main` from rune-ci
- Adds missing event types (`assigned`, `unassigned`, `synchronized`)
- Enables Agent Lane support (claude_cli, gemini_cli, copilot_cli)
- PROJECT_TOKEN secret now set on this repo

## DoD Level
- [ ] **Level 1** — Full Validation
- [x] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence
- [x] Workflow calls `project-sync-logic.yml@main` (diff shows change)
- [x] PROJECT_TOKEN secret configured (verified via `gh secret list`)

## Audit Checks
| Check | Result |
|-------|--------|
| `cyber check:supply-chain` | PASS — workflow change only updates reusable workflow ref, no new dependencies |

## Breaking Changes
None.

## Test plan
- [x] CI workflow syntax validated by GitHub on push
- [x] PROJECT_TOKEN secret verified present on repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)