### PR TITLE
feat(ci): enable automatic chart sync on operator releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,17 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+  attestations: write
+
 jobs:
   release:
-    uses: lpasquali/rune-ci/.github/workflows/release.yml@b242495fb92b046879c9e0ecb8e88a0e89e0e7d5 # main
+    uses: lpasquali/rune-ci/.github/workflows/release.yml@main
     with:
-      image-name: rune-operator
-    permissions:
-      contents: write
-      packages: write
-      id-token: write
-      attestations: write
+      image-name: "rune-operator"
+      notify-charts: true
+    secrets:
+      RUNE_CHARTS_BOT_TOKEN: ${{ secrets.RUNE_CHARTS_BOT_TOKEN }}


### PR DESCRIPTION
## Summary

Enable automatic tag synchronization to `rune-charts` when new operator releases are published, matching the pattern used by the `rune` repo for automated chart updates.

## Changes

- Add `notify-charts: true` parameter to release workflow
- Pass `RUNE_CHARTS_BOT_TOKEN` secret for cross-repo dispatch
- Update workflow to use latest `@main` ref instead of pinned commit
- Move permissions block to top level (matching `rune` pattern)

## DoD Level

- [x] **Level 1** — CI / release automation only (workflow YAML)

## Acceptance Criteria Evidence

- [x] Release workflow passes `notify-charts: true` and `RUNE_CHARTS_BOT_TOKEN` for cross-repo `repository_dispatch` to `rune-charts`.
- [x] Workflow structure aligned with `rune` (top-level permissions, `@main` reusable ref).
- [x] Container build jobs on this PR completed successfully in CI.

## Audit Checks

- **Go quality gates**: PASS — skipped on this PR (no Go path changes); unchanged Go code.
- **Container build**: PASS — amd64/arm64 image jobs succeeded on this PR.
- **CodeQL / secret scanning**: PASS — per latest Actions run on this PR.

## Breaking Changes

None. Release behavior gains an optional charts notify step; existing release artifacts unchanged if token or downstream workflow is misconfigured (dispatch may no-op).

## Test Plan

- [x] CI passes for workflow and container paths touched by this PR.
- [ ] Next operator release will trigger `repository_dispatch` to `rune-charts` (verify after merge).
- [ ] Confirm chart on `main` updates to the published operator image tag (verify after merge).

## Related

- Ensures Helm charts on `main` reference current published operator images when releases ship.
- Completes automated sync infrastructure aligned with the `rune` repo.

Made with [Cursor](https://cursor.com)
