### PR TITLE
chore(ci): add project board backfill workflow

### DIFF
--- a/.github/workflows/project-backfill.yml
+++ b/.github/workflows/project-backfill.yml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# Trigger manually from the Actions tab, or let it run on a schedule.
+# Requires a fine-grained PAT (or classic PAT with `project` scope) stored
+# in the repo secret PROJECT_TOKEN.
+name: Project Board Backfill
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  backfill:
+    uses: lpasquali/rune-ci/.github/workflows/project-backfill-logic.yml@main
+    secrets:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/project-backfill.yml` (scheduled + `workflow_dispatch`) calling `lpasquali/rune-ci/.github/workflows/project-backfill-logic.yml@main` with `PROJECT_TOKEN`.

Closes #92

## DoD Level
- [ ] **Level 1** -- Full Validation
- [x] **Level 2** -- Test Infrastructure
- [ ] **Level 3** -- Documentation Validation

## Acceptance Criteria Evidence
- [x] Matches `project-backfill-caller-template.yml` on rune-ci `main` (post rune-ci#19)
- [x] Parity with existing `project-sync.yml` pattern (thin reusable-workflow caller)

## Audit Checks
No triggers fired.

## Breaking Changes
None.

## Test plan
- [x] Workflow YAML only; validated by repo Quality Gates on PR
