### PR TITLE
feat(operator): RuneBenchmark budget via finops simulate

### DIFF
--- a/api/v1alpha1/runebenchmark_types.go
+++ b/api/v1alpha1/runebenchmark_types.go
@@ -2,6 +2,7 @@
 package v1alpha1
 
 import (
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -45,6 +46,9 @@ type RuneBenchmarkSpec struct {
 	// CostEstimation configures the pre-flight cost safety gate.
 	CostEstimation CostEstimation `json:"costEstimation,omitempty"`
 
+	// Budget optionally caps projected run cost using GET /v1/finops/simulate before the job is submitted.
+	Budget Budget `json:"budget,omitempty"`
+
 	// Agent to run for agentic-agent workflow (e.g. holmes, k8sgpt)
 	Agent string `json:"agent,omitempty"`
 	// When true, demands SLSA L3 signed provenance before execution
@@ -67,6 +71,14 @@ type CostEstimation struct {
 	LocalEnergyRateKWH         float64 `json:"localEnergyRateKwh,omitempty"`
 	LocalHardwarePurchasePrice float64 `json:"localHardwarePurchasePrice,omitempty"`
 	LocalHardwareLifespanYears float64 `json:"localHardwareLifespanYears,omitempty"`
+}
+
+// Budget caps projected run cost using the RUNE finops simulator before job submission.
+type Budget struct {
+	// Maximum allowed cost in USD for this execution (compared to cost_high_usd from GET /v1/finops/simulate
+	// when present, otherwise projected_cost_usd).
+	// +kubebuilder:validation:Minimum=0
+	MaxCostUSD *resource.Quantity `json:"maxCostUSD,omitempty"`
 }
 
 type RunRecord struct {

--- a/api/v1alpha1/types_and_deepcopy_test.go
+++ b/api/v1alpha1/types_and_deepcopy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -63,6 +64,17 @@ func TestAddToSchemeAndDeepCopy(t *testing.T) {
 	}
 	if list.DeepCopyObject() == nil {
 		t.Fatalf("expected list DeepCopyObject result")
+	}
+
+	q := resource.MustParse("5")
+	rb2 := &RuneBenchmark{
+		ObjectMeta: metav1.ObjectMeta{Name: "rb2", Namespace: "ns"},
+		Spec:       RuneBenchmarkSpec{Workflow: "benchmark", APIBaseURL: "http://x", Budget: Budget{MaxCostUSD: &q}},
+	}
+	cp2 := rb2.DeepCopy()
+	*cp2.Spec.Budget.MaxCostUSD = resource.MustParse("9")
+	if rb2.Spec.Budget.MaxCostUSD.AsApproximateFloat64() == 9 {
+		t.Fatalf("deepcopy should not alias budget.maxCostUSD")
 	}
 
 	statusCopy := &RuneBenchmarkStatus{}

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -4,6 +4,7 @@
 package v1alpha1
 
 import (
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -12,8 +13,22 @@ func (in *RuneBenchmark) DeepCopyInto(out *RuneBenchmark) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	out.Spec = in.Spec
+	in.Spec.DeepCopyInto(&out.Spec)
 	in.Status.DeepCopyInto(&out.Status)
+}
+
+func (in *RuneBenchmarkSpec) DeepCopyInto(out *RuneBenchmarkSpec) {
+	*out = *in
+	in.Budget.DeepCopyInto(&out.Budget)
+}
+
+func (in *Budget) DeepCopyInto(out *Budget) {
+	*out = *in
+	if in.MaxCostUSD != nil {
+		inQ, outQ := &in.MaxCostUSD, &out.MaxCostUSD
+		*outQ = new(resource.Quantity)
+		**outQ = **inQ
+	}
 }
 
 func (in *RuneBenchmark) DeepCopy() *RuneBenchmark {

--- a/config/crd/bases/bench.rune.ai_runebenchmarks.yaml
+++ b/config/crd/bases/bench.rune.ai_runebenchmarks.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
-  name: runebenchmarks.
+  name: runebenchmarks.bench.rune.ai
 spec:
-  group: ""
+  group: bench.rune.ai
   names:
     kind: RuneBenchmark
     listKind: RuneBenchmarkList
@@ -29,7 +29,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    name: ""
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/config/crd/bases/bench.rune.ai_runebenchmarks.yaml
+++ b/config/crd/bases/bench.rune.ai_runebenchmarks.yaml
@@ -79,6 +79,20 @@ spec:
               backoffSeconds:
                 format: int32
                 type: integer
+              budget:
+                description: Budget optionally caps projected run cost using GET /v1/finops/simulate
+                  before the job is submitted.
+                properties:
+                  maxCostUSD:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Maximum allowed cost in USD for this execution (compared
+                      to cost_high_usd from GET /v1/finops/simulate when present, otherwise
+                      projected_cost_usd).
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([eE])([+-]?[0-9]+))?$
+                    x-kubernetes-int-or-string: true
+                type: object
               costEstimation:
                 description: CostEstimation configures the pre-flight cost safety
                   gate.

--- a/config/samples/bench_v1alpha1_runebenchmark.yaml
+++ b/config/samples/bench_v1alpha1_runebenchmark.yaml
@@ -16,6 +16,9 @@ spec:
   schedule: "*/15 * * * *"
   timeoutSeconds: 180
   backoffSeconds: 60
+  # Optional: block runs when GET /v1/finops/simulate projected_cost_usd exceeds this cap.
+  budget:
+    maxCostUSD: "10"
   suspend: false
   agent: "holmes"
   attestationRequired: false

--- a/controllers/reconciler_and_http_test.go
+++ b/controllers/reconciler_and_http_test.go
@@ -14,6 +14,7 @@ import (
 	benchv1alpha1 "github.com/lpasquali/rune-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -222,6 +223,53 @@ func TestReconcileSuccessAndStatusUpdate(t *testing.T) {
 	}
 	if len(updated.Status.Conditions) == 0 || updated.Status.Conditions[0].Status != metav1.ConditionTrue {
 		t.Fatalf("expected ready=true condition, got %+v", updated.Status.Conditions)
+	}
+}
+
+func TestReconcileBudgetExceededCondition(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/finops/simulate") {
+			_, _ = w.Write([]byte(`{"projected_cost_usd": 50.0, "cost_high_usd": 100.0}`))
+			return
+		}
+		if r.Method == http.MethodPost {
+			t.Fatal("job POST should not run after budget failure")
+		}
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
+
+	qty := resource.MustParse("1")
+	obj := &benchv1alpha1.RuneBenchmark{
+		ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: "ns", Generation: 1},
+		Spec: benchv1alpha1.RuneBenchmarkSpec{
+			APIBaseURL: ts.URL,
+			Workflow:   "benchmark",
+			Model:      "m",
+			Budget:     benchv1alpha1.Budget{MaxCostUSD: &qty},
+		},
+	}
+	r, _ := buildReconciler(t, obj)
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "rb"}})
+	if err != nil {
+		t.Fatalf("expected reconcile to swallow error, got %v", err)
+	}
+	updated := &benchv1alpha1.RuneBenchmark{}
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "rb"}, updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if updated.Status.LastRun.Status != "failed" {
+		t.Fatalf("expected failed last run, got %+v", updated.Status.LastRun)
+	}
+	found := false
+	for _, c := range updated.Status.Conditions {
+		if c.Type == "Ready" && c.Reason == "BudgetExceeded" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected BudgetExceeded condition, got %+v", updated.Status.Conditions)
 	}
 }
 
@@ -1631,5 +1679,219 @@ func TestCheckCostEstimateExactThreshold(t *testing.T) {
 	err := checkCostEstimate(context.Background(), ts.URL, spec, http.DefaultClient, "")
 	if err != nil {
 		t.Fatalf("expected 0.95 to pass threshold, got %v", err)
+	}
+}
+
+func TestCheckBudgetSkipsWhenNilMax(t *testing.T) {
+	spec := benchv1alpha1.RuneBenchmarkSpec{Budget: benchv1alpha1.Budget{}}
+	if err := checkBudget(context.Background(), "http://unused", spec, http.DefaultClient, ""); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestCheckBudgetAllowsUnderCap(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/finops/simulate" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"projected_cost_usd": 1.5, "cost_high_usd": 2.0, "currency":"USD"}`))
+	}))
+	defer ts.Close()
+
+	qty := resource.MustParse("10")
+	spec := benchv1alpha1.RuneBenchmarkSpec{
+		Workflow: "benchmark",
+		Model:    "llama",
+		Budget:   benchv1alpha1.Budget{MaxCostUSD: &qty},
+	}
+	if err := checkBudget(context.Background(), ts.URL, spec, http.DefaultClient, ""); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+}
+
+func TestCheckBudgetExactCapPasses(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"projected_cost_usd": 10.0, "cost_high_usd": 10.0}`))
+	}))
+	defer ts.Close()
+
+	qty := resource.MustParse("10")
+	spec := benchv1alpha1.RuneBenchmarkSpec{
+		Budget: benchv1alpha1.Budget{MaxCostUSD: &qty},
+	}
+	if err := checkBudget(context.Background(), ts.URL, spec, http.DefaultClient, ""); err != nil {
+		t.Fatalf("expected success at exact cap, got %v", err)
+	}
+}
+
+func TestCheckBudgetBlocksOverCap(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"projected_cost_usd": 50.0, "cost_high_usd": 99.0}`))
+	}))
+	defer ts.Close()
+
+	qty := resource.MustParse("10")
+	spec := benchv1alpha1.RuneBenchmarkSpec{
+		Budget: benchv1alpha1.Budget{MaxCostUSD: &qty},
+	}
+	err := checkBudget(context.Background(), ts.URL, spec, http.DefaultClient, "")
+	if err == nil || !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("expected ErrBudgetExceeded, got %v", err)
+	}
+}
+
+func TestCheckBudgetPrefersCostHighOverProjected(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Mid estimate under cap, but upper bound over cap — must block.
+		_, _ = w.Write([]byte(`{"projected_cost_usd": 1.0, "cost_high_usd": 50.0}`))
+	}))
+	defer ts.Close()
+
+	qty := resource.MustParse("10")
+	spec := benchv1alpha1.RuneBenchmarkSpec{
+		Budget: benchv1alpha1.Budget{MaxCostUSD: &qty},
+	}
+	err := checkBudget(context.Background(), ts.URL, spec, http.DefaultClient, "")
+	if err == nil || !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("expected ErrBudgetExceeded from cost_high_usd, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "cost_high_usd") {
+		t.Fatalf("expected error to name cost_high_usd, got %v", err)
+	}
+}
+
+func TestCheckBudgetFallbackToProjectedWhenCostHighMissing(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"projected_cost_usd": 99.0}`))
+	}))
+	defer ts.Close()
+
+	qty := resource.MustParse("10")
+	spec := benchv1alpha1.RuneBenchmarkSpec{
+		Budget: benchv1alpha1.Budget{MaxCostUSD: &qty},
+	}
+	err := checkBudget(context.Background(), ts.URL, spec, http.DefaultClient, "")
+	if err == nil || !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("expected ErrBudgetExceeded from projected_cost_usd fallback, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "projected_cost_usd") {
+		t.Fatalf("expected error to name projected_cost_usd, got %v", err)
+	}
+}
+
+func TestCheckBudgetNegativeMax(t *testing.T) {
+	q, err := resource.ParseQuantity("-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec := benchv1alpha1.RuneBenchmarkSpec{Budget: benchv1alpha1.Budget{MaxCostUSD: &q}}
+	err = checkBudget(context.Background(), "http://unused", spec, http.DefaultClient, "")
+	if err == nil || !strings.Contains(err.Error(), "maxCostUSD must be >= 0") {
+		t.Fatalf("expected negative max error, got %v", err)
+	}
+}
+
+func TestCheckBudgetBadAPIBaseURL(t *testing.T) {
+	q := resource.MustParse("10")
+	spec := benchv1alpha1.RuneBenchmarkSpec{Budget: benchv1alpha1.Budget{MaxCostUSD: &q}}
+	err := checkBudget(context.Background(), "://bad", spec, http.DefaultClient, "")
+	if err == nil || !strings.Contains(err.Error(), "invalid API base") {
+		t.Fatalf("expected parse error, got %v", err)
+	}
+}
+
+func TestCheckBudgetTransportError(t *testing.T) {
+	q := resource.MustParse("10")
+	spec := benchv1alpha1.RuneBenchmarkSpec{Budget: benchv1alpha1.Budget{MaxCostUSD: &q}}
+	err := checkBudget(context.Background(), "http://127.0.0.1:1", spec, &http.Client{Timeout: 100 * time.Millisecond}, "")
+	if err == nil || !strings.Contains(err.Error(), "HTTP request failed") {
+		t.Fatalf("expected transport error, got %v", err)
+	}
+}
+
+func TestCheckBudgetAPIErrorStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	q := resource.MustParse("10")
+	spec := benchv1alpha1.RuneBenchmarkSpec{Budget: benchv1alpha1.Budget{MaxCostUSD: &q}}
+	err := checkBudget(context.Background(), ts.URL, spec, http.DefaultClient, "")
+	if err == nil || !strings.Contains(err.Error(), "API returned 500") {
+		t.Fatalf("expected API error, got %v", err)
+	}
+}
+
+func TestCheckBudgetInvalidJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{`))
+	}))
+	defer ts.Close()
+
+	q := resource.MustParse("10")
+	spec := benchv1alpha1.RuneBenchmarkSpec{Budget: benchv1alpha1.Budget{MaxCostUSD: &q}}
+	err := checkBudget(context.Background(), ts.URL, spec, http.DefaultClient, "")
+	if err == nil || !strings.Contains(err.Error(), "failed to parse response") {
+		t.Fatalf("expected JSON error, got %v", err)
+	}
+}
+
+func TestCheckBudgetBodyReadError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "no hijack", http.StatusInternalServerError)
+			return
+		}
+		conn, buf, _ := hj.Hijack()
+		_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n")
+		_ = buf.Flush()
+		_ = conn.Close()
+	}))
+	defer ts.Close()
+
+	q := resource.MustParse("10")
+	spec := benchv1alpha1.RuneBenchmarkSpec{Budget: benchv1alpha1.Budget{MaxCostUSD: &q}}
+	err := checkBudget(context.Background(), ts.URL, spec, http.DefaultClient, "")
+	if err == nil || !strings.Contains(err.Error(), "read response") {
+		t.Fatalf("expected read error, got %v", err)
+	}
+}
+
+func TestCheckBudgetSendsTenantAndAuth(t *testing.T) {
+	var gotTenant, gotAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTenant = r.Header.Get("X-Tenant-ID")
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"projected_cost_usd": 0.1}`))
+	}))
+	defer ts.Close()
+
+	q := resource.MustParse("10")
+	spec := benchv1alpha1.RuneBenchmarkSpec{
+		Tenant: "tenant-z",
+		Budget: benchv1alpha1.Budget{MaxCostUSD: &q},
+	}
+	if err := checkBudget(context.Background(), ts.URL, spec, http.DefaultClient, "tok"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotTenant != "tenant-z" || gotAuth != "Bearer tok" {
+		t.Fatalf("tenant=%q auth=%q", gotTenant, gotAuth)
+	}
+}
+
+func TestFinopsSimulateQuery(t *testing.T) {
+	v := finopsSimulateQuery(benchv1alpha1.RuneBenchmarkSpec{
+		Workflow:     "benchmark",
+		Model:        "m1",
+		TemplateHash: "tpl",
+	})
+	if v.Get("suite") != "tpl" || v.Get("model") != "m1" {
+		t.Fatalf("unexpected query: %v", v)
+	}
+	v2 := finopsSimulateQuery(benchv1alpha1.RuneBenchmarkSpec{Workflow: "agentic-agent", Agent: "holmes", Model: "m2"})
+	if v2.Get("agent") != "holmes" || v2.Get("model") != "m2" {
+		t.Fatalf("expected agent and model, got %v", v2)
 	}
 }

--- a/controllers/runebenchmark_controller.go
+++ b/controllers/runebenchmark_controller.go
@@ -6,9 +6,11 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -123,8 +125,12 @@ func (r *RuneBenchmarkReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	if err != nil {
 		obj.Status.ConsecutiveFailures++
-		obj.Status.Conditions = upsertCondition(obj.Status.Conditions, benchv1alpha1.ConditionReady(metav1.ConditionFalse, "RunFailed", err.Error(), obj.Generation))
-		r.Recorder.Eventf(obj, "Warning", "RunFailed", "workflow run failed: %v", err)
+		failReason := "RunFailed"
+		if errors.Is(err, ErrBudgetExceeded) {
+			failReason = "BudgetExceeded"
+		}
+		obj.Status.Conditions = upsertCondition(obj.Status.Conditions, benchv1alpha1.ConditionReady(metav1.ConditionFalse, failReason, err.Error(), obj.Generation))
+		r.Recorder.Eventf(obj, "Warning", failReason, "workflow run failed: %v", err)
 		logger.Error(err, "run failed")
 		metrics.ReconcileTotal.WithLabelValues("error").Inc()
 		if statusErr := r.Status().Update(ctx, obj); statusErr != nil {
@@ -354,6 +360,96 @@ func checkCostEstimate(ctx context.Context, apiBase string, spec benchv1alpha1.R
 	return nil
 }
 
+// ErrBudgetExceeded is returned when the finops estimate (cost_high_usd when present, else projected_cost_usd) exceeds spec.budget.maxCostUSD.
+var ErrBudgetExceeded = errors.New("budget exceeded")
+
+// finopsSimulateResponse is the JSON body from GET /v1/finops/simulate (see rune/rune_bench/metrics/pricing.py).
+type finopsSimulateResponse struct {
+	ProjectedCostUSD float64  `json:"projected_cost_usd"`
+	CostHighUSD      *float64 `json:"cost_high_usd,omitempty"`
+}
+
+// effectiveBudgetUSD returns the USD amount to compare against maxCostUSD: prefer cost_high_usd
+// (stricter upper bound) when present, else projected_cost_usd.
+func effectiveBudgetUSD(p finopsSimulateResponse) (value float64, basis string) {
+	if p.CostHighUSD != nil {
+		return *p.CostHighUSD, "cost_high_usd"
+	}
+	return p.ProjectedCostUSD, "projected_cost_usd"
+}
+
+func finopsSimulateQuery(spec benchv1alpha1.RuneBenchmarkSpec) url.Values {
+	v := url.Values{}
+	if spec.Model != "" {
+		v.Set("model", spec.Model)
+	}
+	switch spec.Workflow {
+	case "agentic-agent":
+		if spec.Agent != "" {
+			v.Set("agent", spec.Agent)
+		}
+	case "benchmark":
+		if spec.TemplateHash != "" {
+			v.Set("suite", spec.TemplateHash)
+		}
+	}
+	return v
+}
+
+// checkBudget calls GET /v1/finops/simulate and blocks the run when the effective estimate
+// (cost_high_usd when present, otherwise projected_cost_usd) exceeds spec.budget.maxCostUSD.
+func checkBudget(ctx context.Context, apiBase string, spec benchv1alpha1.RuneBenchmarkSpec, httpClient *http.Client, token string) error {
+	if spec.Budget.MaxCostUSD == nil {
+		return nil
+	}
+	maxVal := spec.Budget.MaxCostUSD.AsApproximateFloat64()
+	if maxVal < 0 {
+		return fmt.Errorf("budget check: maxCostUSD must be >= 0")
+	}
+
+	raw := strings.TrimRight(apiBase, "/") + "/v1/finops/simulate"
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("budget check: invalid API base: %w", err)
+	}
+	u.RawQuery = finopsSimulateQuery(spec).Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("budget check: failed to build request: %w", err)
+	}
+	if spec.Tenant != "" {
+		req.Header.Set("X-Tenant-ID", spec.Tenant)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("budget check: HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("budget check: failed to read response: %w", err)
+	}
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("budget check: API returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var parsed finopsSimulateResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return fmt.Errorf("budget check: failed to parse response: %w", err)
+	}
+	effective, basis := effectiveBudgetUSD(parsed)
+	if effective > maxVal {
+		return fmt.Errorf("%w: %s %.4f USD exceeds max %.4f USD", ErrBudgetExceeded, basis, effective, maxVal)
+	}
+	return nil
+}
+
 func (r *RuneBenchmarkReconciler) executeBenchmark(ctx context.Context, obj *benchv1alpha1.RuneBenchmark, timeout time.Duration) (benchv1alpha1.RunRecord, error) {
 	record := benchv1alpha1.RunRecord{SubmittedAt: metav1.Now(), Status: "submitted"}
 
@@ -400,6 +496,9 @@ func (r *RuneBenchmarkReconciler) executeBenchmark(ctx context.Context, obj *ben
 	}
 
 	if err := checkCostEstimate(ctx, obj.Spec.APIBaseURL, obj.Spec, clientHTTP, token); err != nil {
+		return record, err
+	}
+	if err := checkBudget(ctx, obj.Spec.APIBaseURL, obj.Spec, clientHTTP, token); err != nil {
 		return record, err
 	}
 


### PR DESCRIPTION
## Summary

Implements **MaxCostUSD** budget enforcement on `RuneBenchmark`: before submitting a job, the reconciler **GET**s `/v1/finops/simulate` (same contract as `rune`’s `PricingSoothSayer.simulate`). The gate compares **`spec.budget.maxCostUSD`** to **`cost_high_usd`** when present (stricter upper bound), otherwise **`projected_cost_usd`**. On violation, **`Ready=False`** with reason **`BudgetExceeded`** and failed last run.

Closes #84
Epic: https://github.com/lpasquali/rune-docs/issues/176

## DoD Level

- [x] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)

## Level 1 Checklist

- [ ] Tested in **docker-compose mode** — *N/A (Kubernetes operator + CRD; no change to `rune` compose stack).*
- [ ] Tested in **kind (Kubernetes) mode** — *Not executed in agent environment (no `helm`/`kind` on PATH). **Reviewer:** `helm install` per DEVELOPER_GUIDE after charts PR.*
- [ ] Tested in **standalone CLI mode** — *N/A.*
- [x] **Breaking change audit**: API versions, persistent data, cross-component contracts — **Additive** `spec.budget` / `maxCostUSD` only; existing specs unchanged. Status conditions: new reason `BudgetExceeded` (additive).
- [x] **Dependency CVE audit** — `go.mod` / `go.sum` unchanged. `govulncheck ./...` attempted; toolchain exited with internal error (no vulnerability report). No new deps introduced.

## Level 2 Checklist

*Skipped — Level 1 selected.*

## Level 3 Checklist

*Skipped.*

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `cyber check:api` | PASS | New behavior is authenticated GET to existing `/v1/finops/simulate`; CRD change is additive (`budget.maxCostUSD`). No new secrets. |

*Other audit triggers: none (no workflow/Dockerfile/go.mod changes in this PR).*

## Acceptance Criteria Evidence

- [x] **Operator blocks runs that violate budget** — `checkBudget` returns `ErrBudgetExceeded` before `POST /v1/jobs/...`; `TestReconcileBudgetExceededCondition` asserts no job POST and `BudgetExceeded` condition.
- [x] **Status conditions show budget failures** — Reconcile maps `errors.Is(err, ErrBudgetExceeded)` → `Ready` reason `BudgetExceeded` (not generic `RunFailed`).

## Test Plan Evidence

- [x] **Unit / envtest-style** — `go test ./...` green; controller tests use `httptest` for finops + job API.
- [x] **Coverage** — Total **99.6%** (floor **99.5%**): `go test ./... -coverprofile=coverage.out -covermode=atomic` → `go tool cover -func=coverage.out` → `total: 99.6%`.

## Breaking Changes

None. Additive CRD fields and new condition reason value.

## Notes for Reviewer

- **rune-charts** companion PR ships the same CRD under `charts/rune-operator/crds/` (Helm 3 CRD install path).
- **CRD metadata fix**: `bench.rune.ai_runebenchmarks.yaml` now has correct `metadata.name`, `spec.group`, and version `name: v1alpha1` (previous file in-tree was invalid).
- Set GitHub project **Status → In progress** when starting; **Done** on merge per project rules.
