### PR TITLE
fix(docker): multi-arch Dockerfile (BUILDPLATFORM / TARGETPLATFORM)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 # syntax=docker/dockerfile:1.7
+#
+# Multi-arch: compile on $BUILDPLATFORM (native builder = fast), emit a binary
+# for $TARGETARCH (set by buildx --platform). CI builds amd64 + arm64 on native
+# runners; local `docker build` must not pin linux/amd64 or arm64 hosts break.
 
 ARG GO_VERSION=1.25
-ARG BUILDPLATFORM=linux/amd64
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 WORKDIR /workspace
 
@@ -11,10 +14,14 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-ARG TARGETOS=linux TARGETARCH=amd64
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -ldflags='-s -w' -o /workspace/bin/rune-operator .
+ARG TARGETOS=linux
+ARG TARGETARCH
+RUN CGO_ENABLED=0 \
+    GOOS=${TARGETOS} \
+    GOARCH=${TARGETARCH:-$(go env GOARCH)} \
+    go build -trimpath -ldflags='-s -w' -o /workspace/bin/rune-operator .
 
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/static-debian12:nonroot
 WORKDIR /
 COPY --from=builder /workspace/bin/rune-operator /manager
 USER 65532:65532


### PR DESCRIPTION
## Summary

Remove hardcoded `linux/amd64` defaults from the operator image Dockerfile so **native arm64 builds** (and buildx `--platform`) work. Runtime stage uses `TARGETPLATFORM` so the distroless base matches the compiled binary.

## Definition of Done

- [x] **Level 2**
- [ ] **Level 1**
- [ ] **Level 3**

## Acceptance Criteria Evidence

- `docker build` succeeds on linux/arm64 without exec-format errors.
- `docker buildx build --platform linux/amd64 --load .` cross-compiles successfully from arm64.

## Audit Checks

No triggers fired.

## Breaking Changes

None. CI already builds amd64 and arm64 on native runners with `platforms:`; this aligns the Dockerfile with those semantics for local and buildx use.

Made with [Cursor](https://cursor.com)