### PR TITLE
feat: optional pprof bind address for manager

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,11 +39,12 @@ var (
 	buildManagerFn   = func(cfg *rest.Config, options ctrl.Options) (managerLike, error) {
 		return ctrl.NewManager(cfg, options)
 	}
-	newManagerFn = func(s *runtime.Scheme, metricsAddr, probeAddr string, enableLeaderElection bool) (managerLike, error) {
+	newManagerFn = func(s *runtime.Scheme, metricsAddr, probeAddr, pprofAddr string, enableLeaderElection bool) (managerLike, error) {
 		return buildManagerFn(getConfigOrDieFn(), ctrl.Options{
 			Scheme:                 s,
 			Metrics:                server.Options{BindAddress: metricsAddr},
 			HealthProbeBindAddress: probeAddr,
+			PprofBindAddress:       pprofAddr,
 			LeaderElection:         enableLeaderElection,
 			LeaderElectionID:       "rune-operator.bench.rune.ai",
 		})
@@ -86,12 +87,14 @@ var (
 func main() {
 	var metricsAddr string
 	var probeAddr string
+	var pprofAddr string
 	var enableLeaderElection bool
 	var estopEnabled bool
 	var estopConfigMapName string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&pprofAddr, "pprof-bind-address", "0", "The address the Go pprof endpoint binds to. Use 0 or empty to disable.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", true, "Enable leader election for controller manager.")
 	flag.BoolVar(&estopEnabled, "estop-enabled", false, "Enable the E-Stop controller.")
 	flag.StringVar(&estopConfigMapName, "estop-configmap-name", controllers.DefaultEStopConfigMapName, "Name of the ConfigMap watched for E-Stop signals.")
@@ -101,13 +104,13 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	if err := run(metricsAddr, probeAddr, enableLeaderElection, estopEnabled, estopConfigMapName); err != nil {
+	if err := run(metricsAddr, probeAddr, pprofAddr, enableLeaderElection, estopEnabled, estopConfigMapName); err != nil {
 		klog.ErrorS(err, "problem running manager")
 		exitFn(1)
 	}
 }
 
-func run(metricsAddr, probeAddr string, enableLeaderElection bool, estopEnabled bool, estopConfigMapName string) error {
+func run(metricsAddr, probeAddr, pprofAddr string, enableLeaderElection bool, estopEnabled bool, estopConfigMapName string) error {
 	s, err := runtimeScheme()
 	if err != nil {
 		return fmt.Errorf("unable to build runtime scheme: %w", err)
@@ -116,7 +119,7 @@ func run(metricsAddr, probeAddr string, enableLeaderElection bool, estopEnabled 
 	shutdownTelemetry := telemetry.SetupOTel("rune-operator")
 	defer shutdownTelemetry()
 
-	mgr, err := newManagerFn(s, metricsAddr, probeAddr, enableLeaderElection)
+	mgr, err := newManagerFn(s, metricsAddr, probeAddr, pprofAddr, enableLeaderElection)
 	if err != nil {
 		return fmt.Errorf("unable to create manager: %w", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -243,7 +243,9 @@ func TestMain_ExitOnRunError(t *testing.T) {
 	setupSignalHandlerFn = func() context.Context { return context.Background() }
 	flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 	os.Args = []string{"cmd"}
-	newManagerFn = func(*runtime.Scheme, string, string, string, bool) (managerLike, error) { return nil, errors.New("boom") }
+	newManagerFn = func(*runtime.Scheme, string, string, string, bool) (managerLike, error) {
+		return nil, errors.New("boom")
+	}
 	setupReconcilerFn = func(managerLike) error { return nil }
 
 	exited := 0

--- a/main_test.go
+++ b/main_test.go
@@ -110,6 +110,9 @@ func TestDefaultNewManagerFnUsesConfiguredOptions(t *testing.T) {
 		if options.HealthProbeBindAddress != ":8081" {
 			t.Fatalf("unexpected probe bind address: %q", options.HealthProbeBindAddress)
 		}
+		if options.PprofBindAddress != "0" {
+			t.Fatalf("unexpected pprof bind address: %q", options.PprofBindAddress)
+		}
 		if !options.LeaderElection {
 			t.Fatalf("expected leader election enabled")
 		}
@@ -119,7 +122,7 @@ func TestDefaultNewManagerFnUsesConfiguredOptions(t *testing.T) {
 		return &fakeManager{}, nil
 	}
 
-	mgr, err := newManagerFn(runtime.NewScheme(), ":8080", ":8081", true)
+	mgr, err := newManagerFn(runtime.NewScheme(), ":8080", ":8081", "0", true)
 	if err != nil {
 		t.Fatalf("expected newManagerFn success, got %v", err)
 	}
@@ -169,51 +172,51 @@ func TestRun_ErrorBranchesAndSuccess(t *testing.T) {
 	setupSignalHandlerFn = func() context.Context { return context.Background() }
 
 	addClientGoSchemeFn = func(*runtime.Scheme) error { return errors.New("scheme-build") }
-	if err := run(":1", ":2", true, false, ""); err == nil || !strings.Contains(err.Error(), "unable to build runtime scheme") {
+	if err := run(":1", ":2", "0", true, false, ""); err == nil || !strings.Contains(err.Error(), "unable to build runtime scheme") {
 		t.Fatalf("expected runtime scheme build error, got %v", err)
 	}
 	addClientGoSchemeFn = oldClientGo
 
-	newManagerFn = func(*runtime.Scheme, string, string, bool) (managerLike, error) {
+	newManagerFn = func(*runtime.Scheme, string, string, string, bool) (managerLike, error) {
 		return nil, errors.New("new-manager")
 	}
-	if err := run(":1", ":2", true, false, ""); err == nil || !strings.Contains(err.Error(), "unable to create manager") {
+	if err := run(":1", ":2", "0", true, false, ""); err == nil || !strings.Contains(err.Error(), "unable to create manager") {
 		t.Fatalf("expected start-manager error, got %v", err)
 	}
 
 	m := &fakeManager{}
-	newManagerFn = func(*runtime.Scheme, string, string, bool) (managerLike, error) { return m, nil }
+	newManagerFn = func(*runtime.Scheme, string, string, string, bool) (managerLike, error) { return m, nil }
 	setupReconcilerFn = func(managerLike) error { return errors.New("setup-reconciler") }
-	if err := run(":1", ":2", true, false, ""); err == nil || !strings.Contains(err.Error(), "unable to create controller") {
+	if err := run(":1", ":2", "0", true, false, ""); err == nil || !strings.Contains(err.Error(), "unable to create controller") {
 		t.Fatalf("expected create-controller error, got %v", err)
 	}
 
 	setupReconcilerFn = func(managerLike) error { return nil }
 	// E-Stop error branch.
 	setupEStopFn = func(managerLike, bool, string) error { return errors.New("estop-err") }
-	if err := run(":1", ":2", true, true, "rune-estop"); err == nil || !strings.Contains(err.Error(), "e-stop controller") {
+	if err := run(":1", ":2", "0", true, true, "rune-estop"); err == nil || !strings.Contains(err.Error(), "e-stop controller") {
 		t.Fatalf("expected e-stop controller error, got %v", err)
 	}
 	setupEStopFn = func(managerLike, bool, string) error { return nil }
 	m.healthErr = errors.New("health")
-	if err := run(":1", ":2", true, false, ""); err == nil || !strings.Contains(err.Error(), "health check") {
+	if err := run(":1", ":2", "0", true, false, ""); err == nil || !strings.Contains(err.Error(), "health check") {
 		t.Fatalf("expected health check error, got %v", err)
 	}
 
 	m.healthErr = nil
 	m.readyErr = errors.New("ready")
-	if err := run(":1", ":2", true, false, ""); err == nil || !strings.Contains(err.Error(), "ready check") {
+	if err := run(":1", ":2", "0", true, false, ""); err == nil || !strings.Contains(err.Error(), "ready check") {
 		t.Fatalf("expected ready check error, got %v", err)
 	}
 
 	m.readyErr = nil
 	m.startErr = errors.New("start")
-	if err := run(":1", ":2", true, false, ""); err == nil || !strings.Contains(err.Error(), "start") {
+	if err := run(":1", ":2", "0", true, false, ""); err == nil || !strings.Contains(err.Error(), "start") {
 		t.Fatalf("expected start error, got %v", err)
 	}
 
 	m.startErr = nil
-	if err := run(":1", ":2", true, false, ""); err != nil {
+	if err := run(":1", ":2", "0", true, false, ""); err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
 	if m.startCalls == 0 {
@@ -240,7 +243,7 @@ func TestMain_ExitOnRunError(t *testing.T) {
 	setupSignalHandlerFn = func() context.Context { return context.Background() }
 	flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 	os.Args = []string{"cmd"}
-	newManagerFn = func(*runtime.Scheme, string, string, bool) (managerLike, error) { return nil, errors.New("boom") }
+	newManagerFn = func(*runtime.Scheme, string, string, string, bool) (managerLike, error) { return nil, errors.New("boom") }
 	setupReconcilerFn = func(managerLike) error { return nil }
 
 	exited := 0


### PR DESCRIPTION
## Summary

Adds `--pprof-bind-address` (default `0` / disabled), wiring controller-runtime `PprofBindAddress` for optional Go `net/http/pprof` access.

Closes #108
Epic: n/a

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 1 Checklist

Skipped (Level 2).

## Level 2 Checklist

- [x] Full test suite passes (`go test ./...` locally; CI gate on PR)
- [x] Coverage not degraded (at or above floor)
- [x] No unintended CI side effects

## Level 3 Checklist

Skipped (Level 2).

## Audit Checks

No triggers fired.

| Check | Result | Evidence |
|---|---|---|
| *(none)* | — | — |

## Acceptance Criteria Evidence

- [x] Flag `--pprof-bind-address` documented in help text — evidence: `main.go` flag definition; CI builds binary
- [x] Controller-runtime receives `PprofBindAddress` — evidence: `ctrl.Options` in `main.go`

## Test Plan Evidence

- [x] `go test ./...` — evidence: green Quality Gates / local run

## Breaking Changes

None.

## Related PRs

- Helm: https://github.com/lpasquali/rune-charts/pull/97
- Python API diagnostics: https://github.com/lpasquali/rune/pull/260

## Notes for Reviewer

Merge before or with chart PR #97; release image tag may need bump for chart consumers.
