### PR TITLE
test: DRY controller test scheme via shared sync.Once helper

### DIFF
--- a/controllers/estop_controller_test.go
+++ b/controllers/estop_controller_test.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -23,13 +22,7 @@ import (
 // seeded with the provided objects.
 func buildEStopReconciler(t *testing.T, objs ...client.Object) *EStopReconciler {
 	t.Helper()
-	s := runtime.NewScheme()
-	if err := benchv1alpha1.AddToScheme(s); err != nil {
-		t.Fatalf("add benchmark scheme: %v", err)
-	}
-	if err := corev1.AddToScheme(s); err != nil {
-		t.Fatalf("add core scheme: %v", err)
-	}
+	s := controllersTestScheme(t)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
 	return &EStopReconciler{Client: c, Scheme: s}
 }
@@ -313,9 +306,7 @@ func (c estopUpdateErrorClient) Update(_ context.Context, _ client.Object, _ ...
 
 // TestEStop_GetError verifies that a non-NotFound error from Get is propagated.
 func TestEStop_GetError(t *testing.T) {
-	s := runtime.NewScheme()
-	_ = corev1.AddToScheme(s)
-	_ = benchv1alpha1.AddToScheme(s)
+	s := controllersTestScheme(t)
 	base := fake.NewClientBuilder().WithScheme(s).Build()
 
 	r := &EStopReconciler{
@@ -333,9 +324,7 @@ func TestEStop_GetError(t *testing.T) {
 
 // TestEStop_GetError_IsNotFound verifies the IsNotFound branch in Get.
 func TestEStop_GetError_IsNotFound(t *testing.T) {
-	s := runtime.NewScheme()
-	_ = corev1.AddToScheme(s)
-	_ = benchv1alpha1.AddToScheme(s)
+	s := controllersTestScheme(t)
 	base := fake.NewClientBuilder().WithScheme(s).Build()
 	r := &EStopReconciler{
 		Client: estopGetErrorClient{
@@ -357,9 +346,7 @@ func TestEStop_ListBenchmarksError(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: DefaultEStopConfigMapName},
 		Data:       map[string]string{"triggered": "true"},
 	}
-	s := runtime.NewScheme()
-	_ = corev1.AddToScheme(s)
-	_ = benchv1alpha1.AddToScheme(s)
+	s := controllersTestScheme(t)
 	base := fake.NewClientBuilder().WithScheme(s).WithObjects(cm).Build()
 	listClient := &estopListErrorClient{Client: base, benchErr: errors.New("list-bench-err")}
 	r := &EStopReconciler{Client: listClient, Scheme: s}
@@ -384,9 +371,7 @@ func TestEStop_ListPodsError(t *testing.T) {
 			Workflow:   "benchmark",
 		},
 	}
-	s := runtime.NewScheme()
-	_ = corev1.AddToScheme(s)
-	_ = benchv1alpha1.AddToScheme(s)
+	s := controllersTestScheme(t)
 	base := fake.NewClientBuilder().WithScheme(s).WithObjects(cm, bench).Build()
 	listClient := &estopListErrorClient{Client: base, podErr: errors.New("list-pod-err")}
 	r := &EStopReconciler{Client: listClient, Scheme: s}
@@ -411,9 +396,7 @@ func TestEStop_UpdateBenchmarkError(t *testing.T) {
 			Workflow:   "benchmark",
 		},
 	}
-	s := runtime.NewScheme()
-	_ = corev1.AddToScheme(s)
-	_ = benchv1alpha1.AddToScheme(s)
+	s := controllersTestScheme(t)
 	base := fake.NewClientBuilder().WithScheme(s).WithObjects(cm, bench).Build()
 
 	r := &EStopReconciler{
@@ -443,9 +426,7 @@ func TestEStop_PatchPodErrorContinues(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pod-fail"},
 	}
-	s := runtime.NewScheme()
-	_ = corev1.AddToScheme(s)
-	_ = benchv1alpha1.AddToScheme(s)
+	s := controllersTestScheme(t)
 	base := fake.NewClientBuilder().WithScheme(s).WithObjects(cm, bench, pod).Build()
 
 	r := &EStopReconciler{
@@ -486,8 +467,7 @@ func (c podPatchErrorClient) Get(ctx context.Context, key types.NamespacedName, 
 
 // TestEStop_SetupWithManager_NilGuard tests the nil manager guard.
 func TestEStop_SetupWithManager_NilGuard(t *testing.T) {
-	s := runtime.NewScheme()
-	_ = corev1.AddToScheme(s)
+	s := controllersTestScheme(t)
 	base := fake.NewClientBuilder().WithScheme(s).Build()
 	r := &EStopReconciler{Client: base, Scheme: s}
 
@@ -503,9 +483,7 @@ func TestEStop_SetupWithManager_Injectable(t *testing.T) {
 	oldSetup := setupEStopControllerWithManager
 	t.Cleanup(func() { setupEStopControllerWithManager = oldSetup })
 
-	s := runtime.NewScheme()
-	_ = corev1.AddToScheme(s)
-	_ = benchv1alpha1.AddToScheme(s)
+	s := controllersTestScheme(t)
 	base := fake.NewClientBuilder().WithScheme(s).Build()
 	r := &EStopReconciler{Client: base, Scheme: s, EStopConfigMapName: "custom-estop"}
 
@@ -616,9 +594,7 @@ func TestAnnotatePodsForScrub_NoBenchmarks(t *testing.T) {
 // TestAnnotatePodsForScrub_BenchmarkListError covers the benchmark List error
 // branch inside annotatePodsForScrub when called directly.
 func TestAnnotatePodsForScrub_BenchmarkListError(t *testing.T) {
-	s := runtime.NewScheme()
-	_ = corev1.AddToScheme(s)
-	_ = benchv1alpha1.AddToScheme(s)
+	s := controllersTestScheme(t)
 	base := fake.NewClientBuilder().WithScheme(s).Build()
 	lc := &estopListErrorClient{Client: base, benchErr: errors.New("bench-list-in-annotate")}
 	r := &EStopReconciler{Client: lc, Scheme: s}

--- a/controllers/reconciler_and_http_test.go
+++ b/controllers/reconciler_and_http_test.go
@@ -96,13 +96,7 @@ func (c failingGetClient) Get(context.Context, client.ObjectKey, client.Object, 
 
 func buildReconciler(t *testing.T, objs ...runtime.Object) (*RuneBenchmarkReconciler, *runtime.Scheme) {
 	t.Helper()
-	s := runtime.NewScheme()
-	if err := benchv1alpha1.AddToScheme(s); err != nil {
-		t.Fatalf("add benchmark scheme: %v", err)
-	}
-	if err := corev1.AddToScheme(s); err != nil {
-		t.Fatalf("add core scheme: %v", err)
-	}
+	s := controllersTestScheme(t)
 	c := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&benchv1alpha1.RuneBenchmark{}).WithRuntimeObjects(objs...).Build()
 	return &RuneBenchmarkReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(50)}, s
 }

--- a/controllers/test_scheme_test.go
+++ b/controllers/test_scheme_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+package controllers
+
+import (
+	"sync"
+	"testing"
+
+	benchv1alpha1 "github.com/lpasquali/rune-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	sharedControllersTestScheme     *runtime.Scheme
+	sharedControllersTestSchemeOnce sync.Once
+	sharedControllersTestSchemeErr  error
+)
+
+// controllersTestScheme returns a shared scheme with api/v1alpha1 and core types
+// registered for controller unit tests (read-only after init).
+func controllersTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	sharedControllersTestSchemeOnce.Do(func() {
+		s := runtime.NewScheme()
+		if err := benchv1alpha1.AddToScheme(s); err != nil {
+			sharedControllersTestSchemeErr = err
+			return
+		}
+		if err := corev1.AddToScheme(s); err != nil {
+			sharedControllersTestSchemeErr = err
+			return
+		}
+		sharedControllersTestScheme = s
+	})
+	if sharedControllersTestSchemeErr != nil {
+		t.Fatalf("controllers test scheme: %v", sharedControllersTestSchemeErr)
+	}
+	return sharedControllersTestScheme
+}


### PR DESCRIPTION
## Summary

Pure test refactor: introduce `controllersTestScheme(t)` (sync.Once-backed) in `controllers/test_scheme_test.go` and replace 11 inline `runtime.NewScheme()+AddToScheme(...)` blocks across `estop_controller_test.go` (10) and `reconciler_and_http_test.go` (1). No production code touched, no API or behavior change.

Closes #112
Epic: #112 <!-- no open parent epic; references closed rune-docs#249 in issue body -->

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 2 Checklist

- [x] Full test suite passes
- [x] Coverage not degraded (at or above floor)
- [x] No unintended CI side effects

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| n/a | No triggers fired | Test-only change; no deps, no API/CRD, no workflows, no Dockerfile, no charts. |

## Acceptance Criteria Evidence

- [x] `go build ./...` clean — `go build ./...` exit 0 on `tests/shared-controllers-scheme-112`.
- [x] `go test ./controllers/... -count=1 -race` passes — `ok github.com/lpasquali/rune-operator/controllers 69.877s coverage: 98.9% of statements`.
- [x] Coverage not regressed vs `main` — both `main` and branch report identical per-package coverage:
  - `rune-operator`: 93.3% (both)
  - `api/v1alpha1`: 100.0% (both)
  - `controllers`: 98.9% (both)
  - `internal/metrics`: 100.0% (both)
  - `internal/telemetry`: 100.0% (both)
- [x] Net diff is negative on the two modified files — `+11 / −41` on the modified files; new helper is `+40` lines (net `+10` overall, all in tests).
- [x] No production `.go` files modified — `git diff --stat` shows only `controllers/*_test.go` and the new `controllers/test_scheme_test.go`.

## Test Plan Evidence

- [x] `/usr/bin/time -v go test ./... -coverprofile=cov.out -count=1 -race` — Exit 0; Maximum resident set size: 822272 KiB (~803 MiB, with `-race`); Wall clock 2:23.35; Go 1.25.0 / linux-arm64. Same RSS profile as `main` (the audit issue rune-operator#97, which was about reducing this, is a separate, already-closed track).

## Breaking Changes

None.

## Notes for Reviewer

- Helper is `sync.Once`-guarded and the returned `*runtime.Scheme` is treated as read-only after init by all callers — equivalent behavior to the previous per-test scheme, just constructed once.
- Parent-epic field on the linked issue references the closed `rune-docs#249` / `rune-operator#97` because there is no open follow-up epic; this PR is incremental cleanup that emerged from that audit.

Made with [Cursor](https://cursor.com)