### PR TITLE
docs(readme): hyperlink IEC 62443-4-1 and SLSA to official specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Kubernetes operator for declarative RUNE job scheduling.
 All documentation is consolidated in the **[RUNE Documentation Site](https://lpasquali.github.io/rune-docs/)**.
 
 ## 🛡️ Compliance
-- **ML4**: This repository is designed to align with **IEC 62443-4-1 ML4** secure development requirements in preparation for future certification.
-- **SLSA**: Build provenance is designed to follow **SLSA Level 3** guidelines.
+- **ML4**: This repository is designed to align with **[IEC 62443-4-1](https://webstore.iec.ch/publication/33615) ML4** secure development requirements in preparation for future certification. ([ISA overview](https://www.isa.org/standards-and-publications/isa-standards/isa-iec-62443-series-of-standards))
+- **SLSA**: Build provenance is designed to follow **[SLSA Level 3](https://slsa.dev/spec/v1.0/)** guidelines.
 
 ## 📜 License
 Apache License 2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

Hyperlinks **IEC 62443-4-1** and **SLSA Level 3** in the README Compliance section to their official spec URLs. URLs come from the rune-docs External Links Catalog.

Closes #116
Epic: —

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [x] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 3 Checklist

- [x] Manual diff review; bare markdown URLs verified syntactically
- [x] Links resolve (HTTP 200/301): webstore.iec.ch, isa.org, slsa.dev

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- [x] IEC 62443-4-1 → IEC Webstore + ISA overview — evidence: `README.md` diff
- [x] SLSA Level 3 → slsa.dev/spec/v1.0 — evidence: `README.md` diff
- [x] No other content changes — evidence: `git diff main --stat` = 1 file, 2/+2 lines

## Test Plan Evidence

- [x] Diff review on `claude/readme-tool-links`
- [x] `curl -sI` for each target URL returned 2xx/3xx

## Breaking Changes

None. Docs-only README change.

## Notes for Reviewer

Cross-repo sweep companion to rune-docs PR #307 / rune#268. Sibling PRs follow for rune-ui, rune-charts, rune-airgapped, rune-audit, rune-ci.