### PR TITLE
Consolidate Dependabot updates and update rune-ci pins

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4

--- a/.github/workflows/project-backfill.yml
+++ b/.github/workflows/project-backfill.yml
@@ -14,6 +14,6 @@ permissions:
 
 jobs:
   backfill:
-    uses: lpasquali/rune-ci/.github/workflows/project-backfill-logic.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5
+    uses: lpasquali/rune-ci/.github/workflows/project-backfill-logic.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   sync:
-    uses: lpasquali/rune-ci/.github/workflows/project-sync-logic.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5
+    uses: lpasquali/rune-ci/.github/workflows/project-sync-logic.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -16,26 +16,26 @@ permissions:
 
 jobs:
   security:
-    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265 # main
+    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
 
   go:
-    uses: lpasquali/rune-ci/.github/workflows/go-quality.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265 # main
+    uses: lpasquali/rune-ci/.github/workflows/go-quality.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
     with:
       coverage-threshold: "99.5"
 
   container:
-    uses: lpasquali/rune-ci/.github/workflows/container-build.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265 # main
+    uses: lpasquali/rune-ci/.github/workflows/container-build.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
     with:
       image-name: "rune-operator"
       push: ${{ github.event_name == 'push' }}
 
   guard:
-    uses: lpasquali/rune-ci/.github/workflows/nginx-ingress-guard.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265 # main
+    uses: lpasquali/rune-ci/.github/workflows/nginx-ingress-guard.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
 
   compliance:
     needs: [security, go, container, guard]
     if: always()
-    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265 # main
+    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
     with:
       needs-json: ${{ toJson(needs) }}
       merge-gate-excludes: "go,container,security,guard" # Force pass

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    uses: lpasquali/rune-ci/.github/workflows/release.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5 # main
+    uses: lpasquali/rune-ci/.github/workflows/release.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
     with:
       image-name: rune-operator
     permissions:


### PR DESCRIPTION
## Summary

Consolidated pending Dependabot GitHub Action updates and updated `rune-ci` reusable workflow pins to the latest baseline.

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 2 Checklist

- [x] Verified workflow YAML syntax
- [x] **CI impact audit**: No changes to build/test logic, only version bumps.
- [x] Verified pinned SHAs match upstream releases.

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `supply-chain check:actions` | PASS | All actions updated to latest pinned SHAs. |

## Acceptance Criteria Evidence

- [x] All GitHub Actions bumped to versions requested by Dependabot.
- [x] All `rune-ci` reusable workflows pinned to SHA `144ef855...`.

## Breaking Changes

None.

## Notes for Reviewer

This PR cleans up automated noise by grouping several Dependabot updates into a single atomic change.
