### PR TITLE
feat(operator): RuneBenchmark.spec.infrastructureRef — Crossplane readiness gate

### DIFF
--- a/api/v1alpha1/runebenchmark_types.go
+++ b/api/v1alpha1/runebenchmark_types.go
@@ -2,6 +2,7 @@
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -48,6 +49,22 @@ type RuneBenchmarkSpec struct {
 
 	// Budget enforces cost limits on benchmarks.
 	Budget Budget `json:"budget,omitempty"`
+
+	// InfrastructureRef optionally references a Crossplane Claim (typically a
+	// RuneDatabase or RuneObjectStore managed via rune-charts/crossplane). When
+	// set, the reconciler waits for the referenced object to report
+	// `type: Synced status: True` AND `type: Ready status: True` before
+	// submitting benchmark jobs, and emits an `InfrastructureNotReady` Warning
+	// event with 30s requeue otherwise. This prevents races where a benchmark
+	// is scheduled before its external dependencies are provisioned.
+	//
+	// The operator reads the referenced object via the generic controller
+	// client using `unstructured.Unstructured`, so no new module dependency on
+	// `crossplane-runtime` is pulled in. For GVKs outside
+	// `database.infra.rune.ai` and `storage.infra.rune.ai` the cluster admin
+	// must grant the operator's ServiceAccount `get` on that group/resource.
+	// +optional
+	InfrastructureRef *corev1.ObjectReference `json:"infrastructureRef,omitempty"`
 }
 
 type Budget struct {

--- a/api/v1alpha1/types_and_deepcopy_test.go
+++ b/api/v1alpha1/types_and_deepcopy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -87,6 +88,45 @@ func TestDeepCopyNilReceivers(t *testing.T) {
 	var list *RuneBenchmarkList
 	if list.DeepCopy() != nil || list.DeepCopyObject() != nil {
 		t.Fatalf("expected nil deep copy/object for nil RuneBenchmarkList")
+	}
+}
+
+// TestSpecDeepCopyInfrastructureRef covers the new InfrastructureRef pointer
+// on RuneBenchmarkSpec: the copy must be independent of the original and the
+// nil-input fast path must not allocate an empty ref.
+func TestSpecDeepCopyInfrastructureRef(t *testing.T) {
+	spec := RuneBenchmarkSpec{
+		Workflow: "wf",
+		InfrastructureRef: &corev1.ObjectReference{
+			APIVersion: "database.infra.rune.ai/v1alpha1",
+			Kind:       "RuneDatabase",
+			Name:       "rune-database",
+			Namespace:  "rune",
+		},
+	}
+	cp := spec.DeepCopy()
+	if cp == nil {
+		t.Fatalf("DeepCopy returned nil")
+	}
+	if cp.InfrastructureRef == spec.InfrastructureRef {
+		t.Fatalf("DeepCopy aliased InfrastructureRef pointer")
+	}
+	cp.InfrastructureRef.Name = "mutated"
+	if spec.InfrastructureRef.Name == "mutated" {
+		t.Fatalf("mutation leaked back to original")
+	}
+
+	// Nil fast path.
+	var nilSpec *RuneBenchmarkSpec
+	if nilSpec.DeepCopy() != nil {
+		t.Fatalf("expected DeepCopy on nil receiver to return nil")
+	}
+
+	// Spec with no InfrastructureRef: copy must not materialise one.
+	bare := RuneBenchmarkSpec{Workflow: "wf"}
+	bareCopy := bare.DeepCopy()
+	if bareCopy.InfrastructureRef != nil {
+		t.Fatalf("DeepCopy of nil-InfrastructureRef spec should leave it nil")
 	}
 }
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -12,8 +12,29 @@ func (in *RuneBenchmark) DeepCopyInto(out *RuneBenchmark) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	out.Spec = in.Spec
+	in.Spec.DeepCopyInto(&out.Spec)
 	in.Status.DeepCopyInto(&out.Status)
+}
+
+// DeepCopyInto copies the fields of a RuneBenchmarkSpec into another,
+// allocating independent storage for the pointer fields (InfrastructureRef
+// today; other pointer fields continue to follow the pre-existing shallow
+// behavior since no prior bug was reported against them).
+func (in *RuneBenchmarkSpec) DeepCopyInto(out *RuneBenchmarkSpec) {
+	*out = *in
+	if in.InfrastructureRef != nil {
+		ref := *in.InfrastructureRef
+		out.InfrastructureRef = &ref
+	}
+}
+
+func (in *RuneBenchmarkSpec) DeepCopy() *RuneBenchmarkSpec {
+	if in == nil {
+		return nil
+	}
+	out := new(RuneBenchmarkSpec)
+	in.DeepCopyInto(out)
+	return out
 }
 
 func (in *RuneBenchmark) DeepCopy() *RuneBenchmark {

--- a/config/crd/bases/bench.rune.ai_runebenchmarks.yaml
+++ b/config/crd/bases/bench.rune.ai_runebenchmarks.yaml
@@ -104,6 +104,31 @@ spec:
                     description: Cloud providers
                     type: boolean
                 type: object
+              infrastructureRef:
+                description: |-
+                  InfrastructureRef optionally references a Crossplane Claim
+                  (typically a RuneDatabase or RuneObjectStore managed via
+                  rune-charts/crossplane). When set, the reconciler waits for
+                  the referenced object to report `Synced=True` AND `Ready=True`
+                  before submitting benchmark jobs. See runebenchmark_types.go
+                  for the full contract.
+                properties:
+                  apiVersion:
+                    type: string
+                  fieldPath:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  resourceVersion:
+                    type: string
+                  uid:
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               insecureTls:
                 type: boolean
               kubeconfig:

--- a/controllers/infrastructure_ref_test.go
+++ b/controllers/infrastructure_ref_test.go
@@ -1,0 +1,453 @@
+// SPDX-License-Identifier: Apache-2.0
+package controllers
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	benchv1alpha1 "github.com/lpasquali/rune-operator/api/v1alpha1"
+)
+
+// newRunedatabaseXR returns an unstructured Crossplane RuneDatabase Claim
+// (group database.infra.rune.ai) stamped with the supplied conditions. Pass
+// nil `conditions` to construct an object with no status yet.
+func newRunedatabaseXR(name, ns string, conditions []map[string]any) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("database.infra.rune.ai/v1alpha1")
+	u.SetKind("RuneDatabase")
+	u.SetName(name)
+	u.SetNamespace(ns)
+	if conditions != nil {
+		condList := make([]any, 0, len(conditions))
+		for _, c := range conditions {
+			condList = append(condList, c)
+		}
+		_ = unstructured.SetNestedSlice(u.Object, condList, "status", "conditions")
+	}
+	return u
+}
+
+// condition builds a Kubernetes-style condition map for a Crossplane XR.
+func condition(t, status string) map[string]any {
+	return map[string]any{
+		"type":               t,
+		"status":             status,
+		"lastTransitionTime": time.Now().Format(time.RFC3339),
+	}
+}
+
+// buildReconcilerWithExtra seeds the scheme-registered fake client with both
+// the RuneBenchmark under test and the infrastructureRef target.
+func buildReconcilerWithExtra(t *testing.T, bench *benchv1alpha1.RuneBenchmark, extras ...client.Object) *RuneBenchmarkReconciler {
+	t.Helper()
+	s := controllersTestScheme(t)
+	objs := []client.Object{bench}
+	objs = append(objs, extras...)
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&benchv1alpha1.RuneBenchmark{}).
+		WithObjects(objs...).
+		Build()
+	return &RuneBenchmarkReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(50)}
+}
+
+func baseBenchmark(ns, name string) *benchv1alpha1.RuneBenchmark {
+	return &benchv1alpha1.RuneBenchmark{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, Generation: 1},
+		Spec: benchv1alpha1.RuneBenchmarkSpec{
+			APIBaseURL: "http://example.invalid",
+			Workflow:   "benchmark",
+			Question:   "ok?",
+		},
+	}
+}
+
+// drainEvents pulls every queued event into a single joined string for
+// assert_contains-style checks without blocking if none are queued.
+func drainEvents(r *RuneBenchmarkReconciler) string {
+	rec, ok := r.Recorder.(*record.FakeRecorder)
+	if !ok {
+		return ""
+	}
+	var got []string
+	for {
+		select {
+		case e := <-rec.Events:
+			got = append(got, e)
+		default:
+			return strings.Join(got, "\n")
+		}
+	}
+}
+
+// TestCheckInfrastructureRef_Nil verifies the fast-path: a benchmark with no
+// infrastructureRef returns (true, "", nil) regardless of cluster state.
+func TestCheckInfrastructureRef_Nil(t *testing.T) {
+	bench := baseBenchmark("rune", "bench")
+	r := buildReconcilerWithExtra(t, bench)
+
+	ready, reason, err := r.checkInfrastructureRef(context.Background(), bench)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ready {
+		t.Fatalf("expected ready=true with no infrastructureRef, got ready=%v reason=%q", ready, reason)
+	}
+	if reason != "" {
+		t.Fatalf("expected empty reason, got %q", reason)
+	}
+}
+
+// TestCheckInfrastructureRef_MissingFields covers the partial-ref case: the
+// user set an infrastructureRef but left one of the three required keys
+// empty. We return not-ready with a descriptive reason and no error.
+func TestCheckInfrastructureRef_MissingFields(t *testing.T) {
+	bench := baseBenchmark("rune", "bench")
+	bench.Spec.InfrastructureRef = &corev1.ObjectReference{
+		APIVersion: "database.infra.rune.ai/v1alpha1",
+		Kind:       "RuneDatabase",
+		// Name intentionally missing
+	}
+	r := buildReconcilerWithExtra(t, bench)
+
+	ready, reason, err := r.checkInfrastructureRef(context.Background(), bench)
+	if err != nil {
+		t.Fatalf("expected nil err for missing fields, got %v", err)
+	}
+	if ready {
+		t.Fatalf("expected ready=false, got ready=true")
+	}
+	if !strings.Contains(reason, "must set") {
+		t.Fatalf("expected 'must set' guidance in reason, got %q", reason)
+	}
+}
+
+// TestCheckInfrastructureRef_BadAPIVersion covers the schema.ParseGroupVersion
+// failure path: malformed apiVersion surfaces as (false, reason, err).
+func TestCheckInfrastructureRef_BadAPIVersion(t *testing.T) {
+	bench := baseBenchmark("rune", "bench")
+	bench.Spec.InfrastructureRef = &corev1.ObjectReference{
+		APIVersion: "not a valid / group / version",
+		Kind:       "RuneDatabase",
+		Name:       "rune-database",
+	}
+	r := buildReconcilerWithExtra(t, bench)
+
+	ready, reason, err := r.checkInfrastructureRef(context.Background(), bench)
+	if ready {
+		t.Fatalf("expected ready=false")
+	}
+	if err == nil {
+		t.Fatalf("expected non-nil error for malformed apiVersion")
+	}
+	if !strings.Contains(reason, "invalid infrastructureRef apiVersion") {
+		t.Fatalf("expected 'invalid apiVersion' reason, got %q", reason)
+	}
+}
+
+// TestCheckInfrastructureRef_NotFound covers the GET-returns-NotFound path.
+// The operator treats a missing target as "not ready yet" (transient) —
+// err is propagated so callers can decide policy, reason describes the miss.
+func TestCheckInfrastructureRef_NotFound(t *testing.T) {
+	bench := baseBenchmark("rune", "bench")
+	bench.Spec.InfrastructureRef = &corev1.ObjectReference{
+		APIVersion: "database.infra.rune.ai/v1alpha1",
+		Kind:       "RuneDatabase",
+		Name:       "absent",
+	}
+	r := buildReconcilerWithExtra(t, bench) // no RuneDatabase in the cluster
+
+	ready, reason, err := r.checkInfrastructureRef(context.Background(), bench)
+	if ready {
+		t.Fatalf("expected ready=false for missing target")
+	}
+	if err == nil {
+		t.Fatalf("expected NotFound error to bubble up")
+	}
+	if !strings.Contains(reason, "cannot fetch infrastructureRef") {
+		t.Fatalf("expected fetch-failure reason, got %q", reason)
+	}
+}
+
+// TestCheckInfrastructureRef_NotReady covers the found-but-conditions-missing
+// and found-but-False paths. Both map to (false, reason, nil) — no error,
+// just a requeue hint.
+func TestCheckInfrastructureRef_NotReady(t *testing.T) {
+	cases := []struct {
+		name   string
+		conds  []map[string]any
+		expect string // substring we want to see in the reason
+	}{
+		{
+			name:   "no conditions yet",
+			conds:  nil,
+			expect: "not ready (Synced=false Ready=false)",
+		},
+		{
+			name: "only Synced=True",
+			conds: []map[string]any{
+				condition("Synced", "True"),
+			},
+			expect: "Synced=true Ready=false",
+		},
+		{
+			name: "Synced=True, Ready=False",
+			conds: []map[string]any{
+				condition("Synced", "True"),
+				condition("Ready", "False"),
+			},
+			expect: "Synced=true Ready=false",
+		},
+		{
+			name: "Synced=False, Ready=True",
+			conds: []map[string]any{
+				condition("Synced", "False"),
+				condition("Ready", "True"),
+			},
+			expect: "Synced=false Ready=true",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bench := baseBenchmark("rune", "bench")
+			bench.Spec.InfrastructureRef = &corev1.ObjectReference{
+				APIVersion: "database.infra.rune.ai/v1alpha1",
+				Kind:       "RuneDatabase",
+				Name:       "rune-database",
+			}
+			xr := newRunedatabaseXR("rune-database", "rune", tc.conds)
+			r := buildReconcilerWithExtra(t, bench, xr)
+
+			ready, reason, err := r.checkInfrastructureRef(context.Background(), bench)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ready {
+				t.Fatalf("expected ready=false, got true (reason=%q)", reason)
+			}
+			if !strings.Contains(reason, tc.expect) {
+				t.Fatalf("expected reason to contain %q, got %q", tc.expect, reason)
+			}
+		})
+	}
+}
+
+// TestCheckInfrastructureRef_Ready covers the happy path: Synced=True AND
+// Ready=True — proceed with benchmark.
+func TestCheckInfrastructureRef_Ready(t *testing.T) {
+	bench := baseBenchmark("rune", "bench")
+	bench.Spec.InfrastructureRef = &corev1.ObjectReference{
+		APIVersion: "database.infra.rune.ai/v1alpha1",
+		Kind:       "RuneDatabase",
+		Name:       "rune-database",
+	}
+	xr := newRunedatabaseXR("rune-database", "rune", []map[string]any{
+		condition("Synced", "True"),
+		condition("Ready", "True"),
+	})
+	r := buildReconcilerWithExtra(t, bench, xr)
+
+	ready, reason, err := r.checkInfrastructureRef(context.Background(), bench)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ready {
+		t.Fatalf("expected ready=true, got false (reason=%q)", reason)
+	}
+	if reason != "" {
+		t.Fatalf("expected empty reason on happy path, got %q", reason)
+	}
+}
+
+// TestCheckInfrastructureRef_NamespaceFallback verifies that leaving
+// ObjectReference.Namespace empty falls back to the RuneBenchmark's namespace.
+func TestCheckInfrastructureRef_NamespaceFallback(t *testing.T) {
+	bench := baseBenchmark("my-rune", "bench")
+	bench.Spec.InfrastructureRef = &corev1.ObjectReference{
+		APIVersion: "database.infra.rune.ai/v1alpha1",
+		Kind:       "RuneDatabase",
+		Name:       "rune-database",
+		// Namespace intentionally empty: must resolve to bench.Namespace.
+	}
+	// Seed the target in a *different* namespace to prove the fallback:
+	// resolving to "my-rune" must succeed, resolving anywhere else must not.
+	xr := newRunedatabaseXR("rune-database", "my-rune", []map[string]any{
+		condition("Synced", "True"),
+		condition("Ready", "True"),
+	})
+	r := buildReconcilerWithExtra(t, bench, xr)
+
+	ready, reason, err := r.checkInfrastructureRef(context.Background(), bench)
+	if err != nil || !ready {
+		t.Fatalf("expected namespace fallback success, got ready=%v err=%v reason=%q", ready, err, reason)
+	}
+}
+
+// TestInfrastructureConditions_MalformedSlice exercises the silent-false path
+// when status.conditions is present but not a well-formed slice-of-maps.
+// Non-map elements are tolerated (ignored) and the result is (false, false).
+func TestInfrastructureConditions_MalformedSlice(t *testing.T) {
+	u := &unstructured.Unstructured{}
+	u.Object = map[string]any{
+		"status": map[string]any{
+			// NestedSlice deep-copies each element with
+			// runtime.DeepCopyJSONValue, so stick to JSON types
+			// (string / float64 / bool / map / slice / nil).
+			"conditions": []any{"not-a-map", float64(42), nil},
+		},
+	}
+	synced, ready := infrastructureConditions(u)
+	if synced || ready {
+		t.Fatalf("expected both false, got synced=%v ready=%v", synced, ready)
+	}
+}
+
+// TestInfrastructureConditions_MissingStatus covers the early-return when the
+// unstructured object has no .status.conditions at all.
+func TestInfrastructureConditions_MissingStatus(t *testing.T) {
+	u := &unstructured.Unstructured{}
+	u.Object = map[string]any{"metadata": map[string]any{"name": "x"}}
+	synced, ready := infrastructureConditions(u)
+	if synced || ready {
+		t.Fatalf("expected both false with no status.conditions, got synced=%v ready=%v", synced, ready)
+	}
+}
+
+// TestReconcile_InfrastructureRefNotReady_Requeues wires the whole reconciler:
+// a benchmark with an unready infrastructureRef must come back with a 30-second
+// requeue, an InfrastructureNotReady Warning event, and NO attempted HTTP call
+// (we use an URL that would explode on connect; the test passes only if the
+// reconciler short-circuited before executeBenchmark).
+func TestReconcile_InfrastructureRefNotReady_Requeues(t *testing.T) {
+	bench := baseBenchmark("rune", "bench")
+	bench.Spec.APIBaseURL = "http://127.0.0.1:1" // closed port; any HTTP call would fail loudly
+	bench.Spec.InfrastructureRef = &corev1.ObjectReference{
+		APIVersion: "database.infra.rune.ai/v1alpha1",
+		Kind:       "RuneDatabase",
+		Name:       "rune-database",
+	}
+	xr := newRunedatabaseXR("rune-database", "rune", []map[string]any{
+		condition("Synced", "True"),
+		condition("Ready", "False"),
+	})
+	r := buildReconcilerWithExtra(t, bench, xr)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "rune", Name: "bench"},
+	})
+	if err != nil {
+		t.Fatalf("expected nil err on not-ready requeue, got %v", err)
+	}
+	if res.RequeueAfter != 30*time.Second {
+		t.Fatalf("expected 30s requeue, got %v", res.RequeueAfter)
+	}
+	ev := drainEvents(r)
+	if !strings.Contains(ev, "InfrastructureNotReady") {
+		t.Fatalf("expected InfrastructureNotReady event, got %q", ev)
+	}
+}
+
+// TestReconcile_InfrastructureRefGetError_Requeues covers the RBAC-denied /
+// NotFound path at reconciler level: it must surface as a 30s requeue with
+// an InfrastructureNotReady event, not a hard reconcile failure.
+func TestReconcile_InfrastructureRefGetError_Requeues(t *testing.T) {
+	bench := baseBenchmark("rune", "bench")
+	bench.Spec.APIBaseURL = "http://127.0.0.1:1"
+	bench.Spec.InfrastructureRef = &corev1.ObjectReference{
+		APIVersion: "database.infra.rune.ai/v1alpha1",
+		Kind:       "RuneDatabase",
+		Name:       "nope",
+	}
+	r := buildReconcilerWithExtra(t, bench) // no XR seeded
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "rune", Name: "bench"},
+	})
+	if err != nil {
+		t.Fatalf("expected nil err on lookup-failure requeue, got %v", err)
+	}
+	if res.RequeueAfter != 30*time.Second {
+		t.Fatalf("expected 30s requeue, got %v", res.RequeueAfter)
+	}
+	ev := drainEvents(r)
+	if !strings.Contains(ev, "InfrastructureNotReady") {
+		t.Fatalf("expected InfrastructureNotReady event, got %q", ev)
+	}
+}
+
+// TestReconcile_InfrastructureRefReady_ProceedsToHTTP verifies that when the
+// ref is ready the reconciler moves past the gate and into executeBenchmark.
+// We point APIBaseURL at a closed port so executeBenchmark FAILS, which is
+// fine: the assertion is that we reached that call at all. Observation:
+// status.lastScheduleTime gets stamped only when the infra gate passes.
+func TestReconcile_InfrastructureRefReady_ProceedsToHTTP(t *testing.T) {
+	bench := baseBenchmark("rune", "bench")
+	bench.Spec.APIBaseURL = "http://127.0.0.1:1" // connect refused -> run.Status=failed
+	bench.Spec.InfrastructureRef = &corev1.ObjectReference{
+		APIVersion: "database.infra.rune.ai/v1alpha1",
+		Kind:       "RuneDatabase",
+		Name:       "rune-database",
+	}
+	xr := newRunedatabaseXR("rune-database", "rune", []map[string]any{
+		condition("Synced", "True"),
+		condition("Ready", "True"),
+	})
+	r := buildReconcilerWithExtra(t, bench, xr)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "rune", Name: "bench"},
+	})
+	// Connection-refused errors are surfaced through the RunFailed
+	// path (RunFailed condition + backoff requeue), not as a reconcile error.
+	if err != nil {
+		t.Fatalf("expected nil err (RunFailed handled via status), got %v", err)
+	}
+
+	var refreshed benchv1alpha1.RuneBenchmark
+	if getErr := r.Get(context.Background(), types.NamespacedName{Namespace: "rune", Name: "bench"}, &refreshed); getErr != nil {
+		t.Fatalf("fetch refreshed bench: %v", getErr)
+	}
+	if refreshed.Status.LastScheduleTime == nil {
+		t.Fatalf("expected LastScheduleTime to be stamped after passing the infra gate")
+	}
+	if refreshed.Status.LastRun.Status != "failed" {
+		t.Fatalf("expected failed RunRecord (closed port), got %q", refreshed.Status.LastRun.Status)
+	}
+	if !strings.Contains(refreshed.Status.LastRun.Error, "connect") &&
+		!strings.Contains(refreshed.Status.LastRun.Error, "refused") &&
+		!errors.Is(err, nil) /* satisfy lint */ {
+		t.Logf("RunRecord.Error (informational): %q", refreshed.Status.LastRun.Error)
+	}
+}
+
+// TestDeepCopy_InfrastructureRefIsIndependent protects against a regression
+// of the pre-existing shallow-copy bug on RuneBenchmarkSpec. Mutating the
+// copy's ref MUST NOT mutate the original's ref.
+func TestDeepCopy_InfrastructureRefIsIndependent(t *testing.T) {
+	orig := baseBenchmark("rune", "bench")
+	orig.Spec.InfrastructureRef = &corev1.ObjectReference{
+		APIVersion: "database.infra.rune.ai/v1alpha1",
+		Kind:       "RuneDatabase",
+		Name:       "rune-database",
+		Namespace:  "rune",
+	}
+
+	cp := orig.DeepCopy()
+	cp.Spec.InfrastructureRef.Name = "different"
+
+	if orig.Spec.InfrastructureRef.Name == cp.Spec.InfrastructureRef.Name {
+		t.Fatalf("DeepCopy aliased InfrastructureRef — mutation leaked to original")
+	}
+}

--- a/controllers/runebenchmark_controller.go
+++ b/controllers/runebenchmark_controller.go
@@ -19,7 +19,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -49,6 +51,8 @@ var jsonMarshal = json.Marshal
 // +kubebuilder:rbac:groups=bench.rune.ai,resources=runebenchmarks/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
+// +kubebuilder:rbac:groups=database.infra.rune.ai,resources=runedatabases;xrunedatabases,verbs=get;list;watch
+// +kubebuilder:rbac:groups=storage.infra.rune.ai,resources=runeobjectstores;xruneobjectstores,verbs=get;list;watch
 
 func (r *RuneBenchmarkReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if mgr == nil {
@@ -98,6 +102,18 @@ func (r *RuneBenchmarkReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if obj.Spec.Suspend {
 		metrics.ReconcileTotal.WithLabelValues("suspended").Inc()
 		return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+	}
+
+	if ready, reason, infraErr := r.checkInfrastructureRef(ctx, obj); infraErr != nil {
+		metrics.ReconcileTotal.WithLabelValues("infra_get_error").Inc()
+		r.Recorder.Eventf(obj, "Warning", "InfrastructureNotReady", reason)
+		logger.Error(infraErr, "infrastructureRef lookup failed", "reason", reason)
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	} else if !ready {
+		metrics.ReconcileTotal.WithLabelValues("infra_not_ready").Inc()
+		r.Recorder.Eventf(obj, "Warning", "InfrastructureNotReady", reason)
+		logger.Info("infrastructureRef not ready; requeuing", "reason", reason)
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
 	now := metav1.Now()
@@ -614,4 +630,79 @@ func nextFromCron(spec string, from time.Time) (time.Time, error) {
 		return time.Time{}, err
 	}
 	return schedule.Next(from), nil
+}
+
+// checkInfrastructureRef evaluates obj.Spec.InfrastructureRef against a live
+// object on the cluster. When the ref is nil the benchmark proceeds
+// normally. When set, the referenced object is fetched via the generic
+// controller client using unstructured.Unstructured (no dynamic client or
+// crossplane-runtime dep) and its .status.conditions are inspected for both
+// `type: Synced status: True` AND `type: Ready status: True`.
+//
+// Return semantics:
+//   - (true,  "", nil)         → proceed with benchmark.
+//   - (false, reason, nil)     → referenced object exists but is not yet
+//     ready; caller should emit an event and requeue. `err` is nil so the
+//     reconciler does not escalate to a transient failure.
+//   - (false, reason, err)     → lookup failure (bad apiVersion, object
+//     missing, RBAC denial). Caller decides how to react; the operator's
+//     Reconcile currently emits a Warning event + 30s requeue rather than
+//     returning the error upstream, matching the existing readiness-gate
+//     style.
+func (r *RuneBenchmarkReconciler) checkInfrastructureRef(ctx context.Context, obj *benchv1alpha1.RuneBenchmark) (bool, string, error) {
+	ref := obj.Spec.InfrastructureRef
+	if ref == nil {
+		return true, "", nil
+	}
+	if ref.APIVersion == "" || ref.Kind == "" || ref.Name == "" {
+		return false, "infrastructureRef must set apiVersion, kind, and name", nil
+	}
+	gv, err := schema.ParseGroupVersion(ref.APIVersion)
+	if err != nil {
+		return false, fmt.Sprintf("invalid infrastructureRef apiVersion %q: %v", ref.APIVersion, err), err
+	}
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(gv.WithKind(ref.Kind))
+	ns := ref.Namespace
+	if ns == "" {
+		ns = obj.Namespace
+	}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: ns, Name: ref.Name}, u); err != nil {
+		return false, fmt.Sprintf("cannot fetch infrastructureRef %s/%s: %v", ref.Kind, ref.Name, err), err
+	}
+	synced, ready := infrastructureConditions(u)
+	if !synced || !ready {
+		return false, fmt.Sprintf(
+			"infrastructureRef %s %s/%s not ready (Synced=%v Ready=%v)",
+			ref.Kind, ns, ref.Name, synced, ready,
+		), nil
+	}
+	return true, "", nil
+}
+
+// infrastructureConditions returns (synced, ready) by walking
+// .status.conditions on the given unstructured object. Crossplane XRs
+// publish both conditions; so does the `Composite` primitive we use for
+// XRuneDatabase / XRuneObjectStore.
+func infrastructureConditions(u *unstructured.Unstructured) (bool, bool) {
+	conds, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
+	if err != nil || !found {
+		return false, false
+	}
+	synced, ready := false, false
+	for _, c := range conds {
+		m, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		t, _ := m["type"].(string)
+		s, _ := m["status"].(string)
+		switch t {
+		case "Synced":
+			synced = s == "True"
+		case "Ready":
+			ready = s == "True"
+		}
+	}
+	return synced, ready
 }


### PR DESCRIPTION
## Summary

Close the deferred Phase 3 of the Crossplane provisioning epic (rune-docs#266). Add `RuneBenchmarkSpec.InfrastructureRef` (optional `*corev1.ObjectReference`); when set, the reconciler blocks the benchmark job submission until the referenced Claim reports `Synced=True` and `Ready=True`, requeuing every 30s with an `InfrastructureNotReady` Warning event otherwise.

Closes #107
Epic: rune-docs#266 (closed)

## DoD Level

- [x] **Level 1 — Full Validation**
- [ ] Level 2
- [ ] Level 3

## Level 1 Checklist

- [x] Tested in **docker-compose mode** — n/a; the operator runs against a cluster, not a compose topology. Unit tests cover the reconciler path end-to-end with a fake Client seeded with unstructured Crossplane XR fixtures.
- [x] Tested in **kind (Kubernetes) mode** — n/a for a purely additive field gated behind an optional ObjectReference. The rune-charts `integration / Deployment Test (K8s 1.34.3 / 1.35.0)` job already installs the operator chart; this PR's CRD schema change is additive and does not affect existing installs.
- [x] Tested in **standalone CLI mode** — n/a; `rune-operator` has no standalone CLI.
- [x] **Breaking change audit** — none. The new field is `+optional`; RuneBenchmarks that do not set `infrastructureRef` keep their current behaviour verbatim. CRD schema adds a property, does not remove or alter existing ones. No persistence / API / cross-component contract changes.
- [x] **Dependency CVE audit** — no new module pulled in. `corev1.ObjectReference` comes from `k8s.io/api/core/v1`, already in `go.mod` via controller-runtime. `unstructured` and `schema` are from `k8s.io/apimachinery`, likewise already present. `govulncheck` + `gosec` run in CI (go-quality).

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `legal check:dep` | PASS | No new Go module dep; only imports already used elsewhere in the controllers. |
| `cyber check:api` | PASS | Additive-only schema change; new field is optional with no default. RBAC markers narrow cluster grants to the two Crossplane groups rune-charts ships compositions for. |
| `cyber check:supply-chain` | PASS | No new image, no new action, no new module. |

## Acceptance Criteria Evidence (from issue)

- [x] **Existing benchmarks without `infrastructureRef` are unaffected** — `TestCheckInfrastructureRef_Nil` asserts the fast-path; the entire pre-existing controllers test suite (~1500 lines) still passes unchanged with **99.0%** coverage.
- [x] **Benchmark with `infrastructureRef` pointing to unready Claim: event emitted, requeue after 30s** — `TestReconcile_InfrastructureRefNotReady_Requeues` and `TestCheckInfrastructureRef_NotReady` (4 sub-cases: no conditions yet; Synced=True only; Synced=True Ready=False; Synced=False Ready=True).
- [x] **Benchmark with `infrastructureRef` pointing to ready Claim: proceeds normally** — `TestReconcile_InfrastructureRefReady_ProceedsToHTTP` verifies we move past the gate into `executeBenchmark` (observable: `Status.LastScheduleTime` gets stamped).
- [x] **Unit tests cover all three cases** — plus 7 more: MissingFields, BadAPIVersion, NotFound (lookup failure), NamespaceFallback, MalformedSlice, MissingStatus, and DeepCopy independence.
- [x] **CRD YAML regenerated** — hand-updated `config/crd/bases/bench.rune.ai_runebenchmarks.yaml` with the `infrastructureRef` property (full `corev1.ObjectReference` schema) in alphabetical order within `spec.properties`.

## Test Plan Evidence

```
$ go build ./...                      # clean
$ go test ./... -count=1 -coverprofile=cov.out
ok      github.com/lpasquali/rune-operator                     coverage: 93.3%
ok      github.com/lpasquali/rune-operator/api/v1alpha1        coverage: 100.0%
ok      github.com/lpasquali/rune-operator/controllers         coverage: 99.0%
ok      github.com/lpasquali/rune-operator/internal/metrics    coverage: 100.0%
ok      github.com/lpasquali/rune-operator/internal/telemetry  coverage: 100.0%

# New tests (all 14 pass):
$ go test ./... -run "InfrastructureRef|SpecDeepCopyInfrastructureRef|InfrastructureConditions" -v
--- PASS: TestCheckInfrastructureRef_Nil
--- PASS: TestCheckInfrastructureRef_MissingFields
--- PASS: TestCheckInfrastructureRef_BadAPIVersion
--- PASS: TestCheckInfrastructureRef_NotFound
--- PASS: TestCheckInfrastructureRef_NotReady (4 sub-cases)
--- PASS: TestCheckInfrastructureRef_Ready
--- PASS: TestCheckInfrastructureRef_NamespaceFallback
--- PASS: TestInfrastructureConditions_MalformedSlice
--- PASS: TestInfrastructureConditions_MissingStatus
--- PASS: TestReconcile_InfrastructureRefNotReady_Requeues
--- PASS: TestReconcile_InfrastructureRefGetError_Requeues
--- PASS: TestReconcile_InfrastructureRefReady_ProceedsToHTTP
--- PASS: TestDeepCopy_InfrastructureRefIsIndependent
--- PASS: TestSpecDeepCopyInfrastructureRef
PASS
```

## Breaking Changes

None.

## Notes for Reviewer

- The reconciler never *returns* an error for InfrastructureRef failures (malformed apiVersion aside): both NotFound/RBAC-denied and "found but not ready" become Warning events + 30s requeues. This keeps the gate from pollutedthe `ReconcileTotal` `error` metric bucket; lookup failures go to a dedicated `infra_get_error` bucket, and logical not-ready into `infra_not_ready`.
- The existing `RuneBenchmarkSpec` DeepCopy was **shallow** (`out.Spec = in.Spec`) — a pre-existing bug that did not cause visible issues because no caller mutated through a copy. I fixed it via a minimal, focused `RuneBenchmarkSpec.DeepCopyInto` that only deep-copies the new `InfrastructureRef` pointer; existing pointer fields (`Provisioning`, `Budget.MaxCostUSD`) keep their previous shallow behaviour to avoid scope creep. A proper `controller-gen`-generated full deep-copy can be a follow-up.
- The MinIO composition shipped in rune-charts#107 does not yet populate `status.conditions` itself (that's the MinIO Tenant CR's job, which Crossplane wraps). For dual-stack Claims (`RuneDatabase` + `RuneObjectStore`) users should apply them separately and reference each from their own RuneBenchmark via `infrastructureRef`. A single-ref-to-many-claims abstraction is explicitly out of scope for this PR.

Made with [Cursor](https://cursor.com)